### PR TITLE
Fix Calendly links based on PR review feedback

### DIFF
--- a/src/components/ai-report/ReportFooter.tsx
+++ b/src/components/ai-report/ReportFooter.tsx
@@ -15,9 +15,9 @@ const ReportFooter = () => {
         <div>
           <h3 className="font-semibold text-lg mb-2 text-primary">Connect with Us</h3>
           <p className="space-y-1">
-            <strong>Website:</strong> <a href="https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call" className="text-secondary hover:underline">GSDat.work</a><br />
+            <strong>Website:</strong> <a href="https://gsdat.work" className="text-secondary hover:underline">GSDat.work</a><br />
             <strong>Email:</strong> <a href="mailto:christian@gsdat.work" className="text-secondary hover:underline">christian@gsdat.work</a><br />
-            <strong>Social:</strong> <a href="https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call" className="text-secondary hover:underline">LinkedIn</a>
+            <strong>Social:</strong> <a href="https://www.linkedin.com/company/gsd-at-work" className="text-secondary hover:underline">LinkedIn</a>
           </p>
         </div>
       </div>

--- a/src/components/services/data.ts
+++ b/src/components/services/data.ts
@@ -50,7 +50,7 @@ export const services: ServiceType[] = [
         price: '$4,999',
         description: 'Led by Christian Ulstrup',
         availability: 'Limited availability',
-        calendlyLink: 'https://calendly.com/gsdatwork/free-consult'
+        calendlyLink: 'https://calendly.com/gsdatwork/ai-workshop'
       },
       {
         label: 'Associate-Led Workshop',


### PR DESCRIPTION
## Summary
- Updated founder workshop Calendly link from `free-consult` to `ai-workshop`
- Fixed report footer links (Website → homepage, LinkedIn → company page)

## Context
These fixes address issues identified during the review of PR #50. During testing, we found:
1. The founder workshop should use the dedicated workshop Calendly link rather than the free consultation link
2. The report footer had incorrect links where "GSDat.work" and "LinkedIn" were pointing to Calendly URLs instead of their proper destinations

@rcorrie874 - FYI, I've made these minor fixes based on Christian's review of your PR. Everything else in your implementation looked great\! The workshop pricing tiers and round-robin routing are working perfectly.

## Test plan
- [x] Verify founder workshop "Book Workshop Now" button uses `ai-workshop` link
- [x] Verify report footer "GSDat.work" links to homepage
- [x] Verify report footer "LinkedIn" links to company LinkedIn page
- [x] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)