### PR TITLE
Fix download button on Triple-A Transformation page

### DIFF
--- a/src/pages/methodology/TripleAFramework.tsx
+++ b/src/pages/methodology/TripleAFramework.tsx
@@ -148,7 +148,7 @@ const TripleAFramework = () => {
                 size="lg"
                 variant="outline"
                 className={`${buttonStyles.outline.primary} ${shadows.buttonEffect}`}
-                onClick={() => window.location.href = "#download"}
+                onClick={() => window.open("/downloads/triple-a-tracker-template.csv", "_blank")}
               >
                 <Download className="mr-2 h-5 w-5" />
                 Download Framework


### PR DESCRIPTION
## Summary
- Fixed the "Download Framework" button that was only scrolling down the page
- Now it properly downloads the Triple-A tracker template CSV file

## Test plan
- [x] Navigate to the Triple-A Transformation page
- [x] Click the "Download Framework" button in the hero section
- [x] Verify it downloads the triple-a-tracker-template.csv file instead of just scrolling

🤖 Generated with [Claude Code](https://claude.ai/code)