### PR TITLE
Fix Boss badge with static version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions](https://github.com/culstrup/get-stuff-done-ai/workflows/CI/badge.svg)](https://github.com/culstrup/get-stuff-done-ai/actions)
 [![codecov](https://codecov.io/gh/culstrup/get-stuff-done-ai/graph/badge.svg)](https://codecov.io/gh/culstrup/get-stuff-done-ai)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/49513722-08c3-4e06-8f9d-f6f3732a3b15/deploy-status)](https://app.netlify.com/sites/deft-florentine-69dcb4/deploys)
-[![Boss Bounties](https://img.shields.io/endpoint?url=https%3A%2F%2Fwww.boss.dev%2Fshield%2Fgithub%2Frepos%2Fculstrup%2Fget-stuff-done-ai)](https://www.boss.dev/issues/repo/github/culstrup/get-stuff-done-ai)
+[![Boss Bounties](https://img.shields.io/badge/Boss-Bounties-orange?logo=github)](https://www.boss.dev/issues/repo/culstrup/get-stuff-done-ai)
 
 **Live Site**: https://gsdat.work
 


### PR DESCRIPTION
## Summary
Replaced the non-working Boss.dev endpoint badge with a static shields.io badge.

## Problem
The Boss.dev endpoint badge was showing "path does not exist" error. After investigating:
- The endpoint URL format appears to be correct based on documentation
- Tried multiple URL variations without success
- Boss.dev seems to focus on in-issue bounty display rather than README badges

## Solution
Using a static shields.io badge that:
- Shows "Boss Bounties" with an orange color
- Links to the correct Boss.dev page for the repository
- Uses the GitHub logo for consistency

The badge now works reliably and still directs users to view active bounties.

🤖 Generated with [Claude Code](https://claude.ai/code)