### PR TITLE
Fix Boss badge with correct API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions](https://github.com/culstrup/get-stuff-done-ai/workflows/CI/badge.svg)](https://github.com/culstrup/get-stuff-done-ai/actions)
 [![codecov](https://codecov.io/gh/culstrup/get-stuff-done-ai/graph/badge.svg)](https://codecov.io/gh/culstrup/get-stuff-done-ai)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/49513722-08c3-4e06-8f9d-f6f3732a3b15/deploy-status)](https://app.netlify.com/sites/deft-florentine-69dcb4/deploys)
-[![Boss Bounties](https://img.shields.io/endpoint?url=https%3A%2F%2Fwww.boss.dev%2Fshield%2Fgithub%2Frepos%2Fculstrup%2Fget-stuff-done-ai)](https://www.boss.dev/issues/repo/github/culstrup/get-stuff-done-ai)
+[![Boss Bounty Badge](https://img.shields.io/endpoint.svg?url=https://api.boss.dev/badge/enabled/culstrup/get-stuff-done-ai)](https://www.boss.dev/issues/repo/culstrup/get-stuff-done-ai)
 
 **Live Site**: https://gsdat.work
 


### PR DESCRIPTION
## Summary
Fixed the Boss.dev badge using the correct URL format from their documentation.

## Changes
- Changed from `www.boss.dev` to `api.boss.dev`
- Used the correct path: `/badge/enabled/culstrup/get-stuff-done-ai`
- Added `.svg` extension to the endpoint URL
- Kept the link pointing to the Boss issues page

The badge should now display properly showing "boss enabled" status.

🤖 Generated with [Claude Code](https://claude.ai/code)