### PR TITLE
fix: Disable Manifold workflows for resolved issue #59

### DIFF
--- a/.github/workflows/manifold-deadline.yml
+++ b/.github/workflows/manifold-deadline.yml
@@ -1,17 +1,22 @@
 name: Check Manifold Market Deadline
 
+# DISABLED: Market for issue #59 has been resolved
+# To re-enable for a new issue/market:
+# 1. Uncomment the schedule in 'on' section below
+# 2. Update MARKET_ID, TARGET_ISSUE, and DEADLINE_TIMESTAMP in env section
+
 on:
-  schedule:
-    # Run every hour
-    # Will check deadline (Aug 6, 2025 9PM ET) and resolve if needed
-    - cron: '0 * * * *'
+  # schedule:
+  #   # Run every hour
+  #   # Will check deadline and resolve if needed
+  #   - cron: '0 * * * *'
   workflow_dispatch: # Allow manual trigger for testing
 
 env:
-  MARKET_ID: "nQIuhZd9O8"
-  TARGET_ISSUE: "59"
+  MARKET_ID: "nQIuhZd9O8"  # Update this for new markets
+  TARGET_ISSUE: "59"  # Update this for new issues
   # August 6, 2025 9PM ET (Unix timestamp in milliseconds)
-  DEADLINE_TIMESTAMP: "1754528400000"
+  DEADLINE_TIMESTAMP: "1754528400000"  # Update this for new deadlines
 
 permissions:
   contents: read

--- a/.github/workflows/manifold-resolve.yml
+++ b/.github/workflows/manifold-resolve.yml
@@ -1,14 +1,23 @@
 name: Resolve Manifold Market on PR Merge
 
+# DISABLED: Market for issue #59 has been resolved
+# To re-enable for a new issue/market:
+# 1. Uncomment the 'on' section below
+# 2. Update MARKET_ID and TARGET_ISSUE in env section
+# 3. Update the issue number in the job conditions
+
+# on:
+#   pull_request:
+#     types: [closed]
+#   issues:
+#     types: [labeled]
+
 on:
-  pull_request:
-    types: [closed]
-  issues:
-    types: [labeled]
+  workflow_dispatch: # Only manual trigger for now
 
 env:
-  MARKET_ID: "nQIuhZd9O8"
-  TARGET_ISSUE: "59"
+  MARKET_ID: "nQIuhZd9O8"  # Update this for new markets
+  TARGET_ISSUE: "59"  # Update this for new issues
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
This PR disables the automatic Manifold market resolution workflows since the market for issue #59 has been successfully resolved to YES.

## Problem
- The workflows were triggering on every PR merge and failing
- The market is already resolved, so the workflows serve no purpose
- Unnecessary GitHub Actions notifications were being sent

## Solution
- Commented out automatic triggers (PR merge events and hourly schedule)
- Workflows now only run on manual dispatch (workflow_dispatch)
- Added clear instructions for re-enabling for future markets
- Preserved the workflow files as templates for future use

## Changes
- 📝 Updated  - disabled automatic PR triggers
- 📝 Updated  - disabled scheduled runs

## Future Use
When you want to use these workflows for a new bounty/market:
1. Uncomment the trigger sections
2. Update the MARKET_ID and TARGET_ISSUE variables
3. Update the DEADLINE_TIMESTAMP for deadline workflow
4. Commit and the automation will be active again

This keeps the infrastructure in place for future Manifold markets while preventing unnecessary failures.