### PR TITLE
Add Vapi voice widget to confirmation page and remove phone CTAs

### DIFF
--- a/src/components/EnhancedFooter.tsx
+++ b/src/components/EnhancedFooter.tsx
@@ -51,14 +51,6 @@ export const EnhancedFooter = () => {
             {/* Contact Info */}
             <div className="space-y-3">
               <a
-                href="tel:+18482610259"
-                className="flex items-center text-primary hover:text-secondary transition-colors group"
-                aria-label="Call our AI Assistant"
-              >
-                <Phone className="h-4 w-4 mr-2 group-hover:scale-110 transition-transform" />
-                <span className="font-medium">AI Assistant: (848) 261-0259</span>
-              </a>
-              <a
                 href="mailto:hello@gsdat.work"
                 className="flex items-center text-primary hover:text-secondary transition-colors group"
                 aria-label="Email Us"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { Phone, MessageSquare, Linkedin } from "lucide-react";
+import { MessageSquare, Linkedin } from "lucide-react";
 
 export const Footer = () => {
   const currentYear = new Date().getFullYear();
@@ -8,21 +8,12 @@ export const Footer = () => {
   const subject = "Website Inquiry";
   const mailtoLink = `mailto:${email}?subject=${encodeURIComponent(subject)}`;
   const linkedInUrl = "https://www.linkedin.com/company/100624720";
-  const phoneNumber = "+18482610259";
 
   return (
     <footer className="mt-20 pb-8 text-sm text-gray-600">
       <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
         <div>© {currentYear} GSD at Work LLC</div>
         <div className="flex items-center flex-wrap gap-4 justify-center">
-          <a
-            href={`tel:${phoneNumber}`}
-            className="text-primary hover:text-primary-light transition-colors flex items-center gap-1"
-            aria-label="Call our AI Assistant"
-          >
-            <Phone className="h-4 w-4" />
-            <span>AI Assistant: (848) 261-0259</span>
-          </a>
           <a
             href={mailtoLink}
             className="text-primary hover:text-primary-light transition-colors flex items-center gap-1"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -76,17 +76,6 @@ export const Hero = () => {
               <span className="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full animate-ping"></span>
               <span className="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full"></span>
             </Button>
-            <Button
-              variant="outline"
-              className={`${buttonStyles.outline.primary} ${buttonStyles.sizes.large} ${typography.touchTargets.button} gap-2 w-full sm:w-auto ${buttonStyles.effects.borderGlow} hover:border-primary/70 hover:bg-primary/5`}
-              onClick={() => window.location.href = "tel:+18482610259"}
-            >
-              <Phone className="h-4 w-4 group-hover:rotate-12 transition-transform duration-300" />
-              <span>
-                <span className="font-medium">Speak with our AI Assistant</span>
-                <span className="block text-xs md:text-sm">(848) 261-0259</span>
-              </span>
-            </Button>
           </div>
         </div>
       </div>

--- a/src/components/ai-report/ReportCTA.tsx
+++ b/src/components/ai-report/ReportCTA.tsx
@@ -1,7 +1,7 @@
 
 import React from "react";
 import { Button } from "@/components/ui/button";
-import { Calendar, Phone } from "lucide-react";
+import { Calendar } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
 const ReportCTA = () => {
@@ -16,20 +16,12 @@ const ReportCTA = () => {
     });
   };
 
-  const handleSpeakWithAI = () => {
-    window.location.href = "tel:+18482610259";
-    toast({
-      title: "Phone call initiated",
-      description: "You're being connected to our AI assistant.",
-      duration: 3000,
-    });
-  };
 
   return (
     <section id="get-started" className="bg-gradient-to-r from-secondary/20 to-secondary/5 p-8 rounded-xl mb-12 shadow-sm">
       <h2 className="text-2xl font-bold mb-6 text-primary">Get a Personalized AI Tool Recommendation</h2>
       <p className="mb-6">
-        Want to know which AI tools would best fit your specific business needs and budget? Schedule a free consultation with our team or speak with our AI assistant for personalized recommendations.
+        Want to know which AI tools would best fit your specific business needs and budget? Schedule a free consultation with our team for personalized recommendations.
       </p>
       <div className="flex flex-col sm:flex-row gap-4">
         <Button
@@ -39,15 +31,6 @@ const ReportCTA = () => {
         >
           <Calendar className="h-4 w-4 text-white" aria-hidden="true" />
           <span className="text-white">Schedule Free Consultation</span>
-        </Button>
-        <Button
-          variant="outline"
-          className="border border-secondary text-secondary hover:bg-secondary/10 gap-2"
-          onClick={handleSpeakWithAI}
-          aria-label="Speak with our AI assistant via phone"
-        >
-          <Phone className="h-4 w-4" aria-hidden="true" />
-          Speak with our AI Assistant
         </Button>
       </div>
       

--- a/src/components/internal-linking/ServiceComparison.tsx
+++ b/src/components/internal-linking/ServiceComparison.tsx
@@ -279,11 +279,6 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             </a>
-            <a href="tel:+18482610259" className="relative z-20">
-              <Button variant="outline" className="border-secondary text-secondary hover:bg-secondary hover:text-white px-8 py-3 relative z-20">
-                Call AI Assistant: (848) 261-0259
-              </Button>
-            </a>
           </div>
         </div>
       </div>

--- a/src/components/navigation/DesktopNavigation.tsx
+++ b/src/components/navigation/DesktopNavigation.tsx
@@ -245,18 +245,6 @@ export const DesktopNavigation = () => {
       </NavigationMenu>
       
       <Button
-        variant="outline"
-        className={`ml-4 ${buttonStyles.outline.primary} gap-2 ${shadows.buttonEffect}`}
-        onClick={() => window.location.href = "tel:+18482610259"}
-      >
-        <Phone className="h-4 w-4" />
-        <span>
-          <span className="font-medium">Call</span>
-          <span className="hidden lg:block text-xs">(848) 261-0259</span>
-        </span>
-      </Button>
-      
-      <Button
         className={`ml-2 ${buttonStyles.primary} ${shadows.buttonEffect}`}
         onClick={() => window.open("https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call", "_blank")}
       >

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -85,14 +85,6 @@ export const MobileNavigation = () => {
             >
               Book a Strategy Call
             </Button>
-            <Button
-              variant="outline"
-              className="w-full border border-primary text-primary hover:bg-primary/10 gap-2 py-6"
-              onClick={() => window.location.href = "tel:+18482610259"}
-            >
-              <Phone className="h-4 w-4" />
-              <span>(848) 261-0259</span>
-            </Button>
           </div>
         </div>
       </SheetContent>

--- a/src/components/services/ValueMetricsSection.tsx
+++ b/src/components/services/ValueMetricsSection.tsx
@@ -45,17 +45,6 @@ export const ValueMetricsSection = () => {
           >
             See Client Success Stories
           </Button>
-          <Button
-            variant="outline"
-            className="border border-primary text-primary hover:bg-primary/10 gap-2"
-            onClick={() => window.location.href = "tel:+18482610259"}
-          >
-            <Phone className="h-4 w-4" />
-            <span>
-              <span className="font-medium">Talk to our AI Assistant</span>
-              <span className="block text-xs">(848) 261-0259</span>
-            </span>
-          </Button>
         </div>
         <p className="text-gray-600">
           Or{" "}

--- a/src/pages/StrategySessionConfirmed.tsx
+++ b/src/pages/StrategySessionConfirmed.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
-import { CheckCircle2, Linkedin, Phone } from "lucide-react";
+import { CheckCircle2, Linkedin, Mic, Headphones } from "lucide-react";
 import { SEOHead } from "@/components/SEOHead";
 import { Layout } from "@/components/Layout";
 
@@ -27,30 +27,49 @@ const StrategySessionConfirmed = () => {
         canonicalUrl="https://gsdat.work/strategy-session-confirmed"
         keywords="AI strategy session, AI consulting, AI implementation consultation, business transformation"
       />
-      <div className="min-h-screen bg-background flex items-center justify-center py-24 sm:py-32">
-      <div className="mx-auto max-w-2xl px-6 lg:px-8 text-center">
-        <CheckCircle2 className="mx-auto h-16 w-16 text-secondary mb-6" />
-        <h1 className="text-3xl font-bold tracking-tight text-primary sm:text-4xl mb-4">
-          Looking forward to speaking with you very soon
+      
+      {/* Vapi Voice Widget Script */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function() {
+              var script = document.createElement('script');
+              script.src = 'https://unpkg.com/@vapi-ai/client-sdk-react/dist/embed/widget.umd.js';
+              script.async = true;
+              script.type = 'text/javascript';
+              document.body.appendChild(script);
+            })();
+          `
+        }}
+      />
+      
+      <div className="min-h-screen bg-background flex items-center justify-center py-12 sm:py-16 md:py-24">
+      <div className="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8 text-center w-full">
+        <CheckCircle2 className="mx-auto h-12 sm:h-16 w-12 sm:w-16 text-secondary mb-4 sm:mb-6" />
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-primary sm:text-4xl mb-4 px-2">
+          Your Strategy Session is Confirmed!
         </h1>
+        <p className="text-base sm:text-lg text-gray-600 mb-6 px-2">
+          I'm looking forward to speaking with you very soon.
+        </p>
         
-        <div className="mt-8 space-y-6 text-left bg-gray-50 p-8 rounded-lg">
-          <h2 className="text-xl font-semibold text-primary">What to Expect</h2>
-          <ul className="space-y-4 text-gray-600">
+        <div className="mt-6 sm:mt-8 space-y-4 sm:space-y-6 text-left bg-gray-50 p-4 sm:p-6 md:p-8 rounded-lg">
+          <h2 className="text-lg sm:text-xl font-semibold text-primary">What to Expect</h2>
+          <ul className="space-y-3 sm:space-y-4 text-sm sm:text-base text-gray-600">
             <li className="flex items-start">
-              <svg className="h-6 w-6 text-secondary flex-shrink-0 mt-1" viewBox="0 0 20 20" fill="currentColor">
+              <svg className="h-5 w-5 sm:h-6 sm:w-6 text-secondary flex-shrink-0 mt-0.5 sm:mt-1" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
               </svg>
               <span className="ml-3">Identify your highest-impact AI opportunity</span>
             </li>
             <li className="flex items-start">
-              <svg className="h-6 w-6 text-secondary flex-shrink-0 mt-1" viewBox="0 0 20 20" fill="currentColor">
+              <svg className="h-5 w-5 sm:h-6 sm:w-6 text-secondary flex-shrink-0 mt-0.5 sm:mt-1" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
               </svg>
               <span className="ml-3">Map out your 30-day quick win</span>
             </li>
             <li className="flex items-start">
-              <svg className="h-6 w-6 text-secondary flex-shrink-0 mt-1" viewBox="0 0 20 20" fill="currentColor">
+              <svg className="h-5 w-5 sm:h-6 sm:w-6 text-secondary flex-shrink-0 mt-0.5 sm:mt-1" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
               </svg>
               <span className="ml-3">Design your execution roadmap</span>
@@ -58,24 +77,45 @@ const StrategySessionConfirmed = () => {
           </ul>
         </div>
 
-        <div className="mt-8">
-          <div className="bg-secondary/5 border-2 border-secondary rounded-lg p-6 mb-8">
-            <h3 className="font-bold text-lg text-primary mb-3">📞 Important Next Step</h3>
-            <p className="text-gray-600 mb-4">
-              To make our session as valuable as possible, please take 2 minutes to speak with our AI assistant. This helps me customize the session specifically for your needs.
+        <div className="mt-6 sm:mt-8">
+          <div className="bg-gradient-to-br from-secondary/10 to-secondary/5 border-2 border-secondary rounded-xl p-4 sm:p-6 mb-6 sm:mb-8 shadow-lg">
+            <div className="flex items-center justify-center mb-4">
+              <div className="bg-secondary/20 p-3 rounded-full">
+                <Mic className="h-6 w-6 sm:h-8 sm:w-8 text-secondary" />
+              </div>
+            </div>
+            <h3 className="font-bold text-lg sm:text-xl text-primary mb-3">🎯 Let's Prepare for Maximum Value</h3>
+            <p className="text-sm sm:text-base text-gray-700 mb-4">
+              Take 2 minutes to share your biggest AI challenges with our intake assistant. This helps me customize our strategy session specifically for your needs.
             </p>
-            <a 
-              href="tel:+14159917188" 
-              className="inline-flex items-center justify-center w-full bg-secondary text-white py-3 px-4 rounded-md hover:bg-secondary/90 transition-colors"
-            >
-              <Phone className="h-5 w-5 mr-2" />
-              Call AI Assistant Now: +1 (415) 991-7188
-            </a>
+            <div className="bg-white/70 rounded-lg p-3 sm:p-4 mb-4 border border-secondary/20">
+              <p className="text-xs sm:text-sm text-gray-600 mb-2">
+                <strong>Quick & Easy:</strong> Just click the button below and start talking. Our AI will guide you through a few questions.
+              </p>
+              <div className="flex items-center justify-center gap-2 text-secondary">
+                <Headphones className="h-4 w-4" />
+                <span className="text-xs sm:text-sm font-medium">Works best with headphones</span>
+              </div>
+            </div>
+            
+            {/* Vapi Voice Widget */}
+            <div className="flex justify-center">
+              <vapi-widget 
+                assistant-id="dc07664b-8543-4305-8a39-686f1f3a50da" 
+                public-key="2e1fbe06-baf7-42e0-98b5-6c5a034288ca"
+              ></vapi-widget>
+            </div>
+            
+            <p className="text-xs text-gray-500 mt-3 italic">
+              💡 Tip: Click the microphone to start a conversation
+            </p>
           </div>
           
-          <p className="text-gray-600 mb-6">
-            Please check your email for the meeting details and Google Meet link.
-          </p>
+          <div className="bg-gray-50 rounded-lg p-4 mb-6">
+            <p className="text-sm sm:text-base text-gray-600">
+              📧 <strong>Check your email</strong> for the meeting details and Google Meet link.
+            </p>
+          </div>
           <a 
             href="https://www.linkedin.com/in/christianulstrup/" 
             target="_blank" 


### PR DESCRIPTION
## Summary
- Integrated Vapi voice widget on the strategy session confirmation page for immediate AI intake
- Removed all phone number CTAs across the site
- Enhanced mobile responsiveness for the confirmation page

## Changes Made

### Voice Widget Integration
- Embedded Vapi voice widget on `/strategy-session-confirmed` page
- Added assistant ID and public key provided by the user
- Included script tag for loading the Vapi widget SDK

### Phone Number CTA Removal
Removed phone number buttons and references from:
- Homepage Hero section
- Desktop and Mobile navigation
- Footer components (both Footer and EnhancedFooter)
- AI report CTA section
- Service comparison section
- Value metrics section

### UI/UX Improvements
- Updated confirmation page copy to encourage immediate voice interaction
- Added visual cues (microphone icon, headphones recommendation)
- Improved mobile responsiveness with responsive sizing classes
- Created a more engaging design with gradient backgrounds and better spacing
- Added helpful tips and instructions for using the voice widget

## Testing
- ✅ Local development server running successfully
- ✅ All phone CTAs removed from identified components
- ✅ Voice widget properly embedded on confirmation page
- ✅ Mobile responsive design implemented

## Next Steps
The voice widget should now appear on the confirmation page after users book a strategy session. Users can click the microphone to start a conversation with the AI assistant for intake purposes.

🤖 Generated with [Claude Code](https://claude.ai/code)