### PR TITLE
Include associate program and methodology in sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 
 User-agent: *
 Disallow: /private-files/
+Sitemap: https://gsdat.work/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,61 +3,73 @@
   
   <url>
     <loc>https://gsdat.work/</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://gsdat.work/cases</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-tooling-report</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/10x-executive</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-action-workshop</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-legal-workshop</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-automation-integration</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://gsdat.work/associate-program</loc>
+    <lastmod>2025-08-25</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://gsdat.work/methodology</loc>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/triple-a-transformation</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/blog</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/qualitative-data-insights-workshop</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/public/sitemap.xml.cjs
+++ b/public/sitemap.xml.cjs
@@ -86,14 +86,26 @@ const generateSitemap = () => {
       changefreq: 'weekly',
       priority: '0.9'
     },
-    { 
-      url: 'https://gsdat.work/ai-automation-integration', 
+    {
+      url: 'https://gsdat.work/ai-automation-integration',
       lastmod: today,
       changefreq: 'weekly',
       priority: '0.9'
     },
-    { 
-      url: 'https://gsdat.work/triple-a-transformation', 
+    {
+      url: 'https://gsdat.work/associate-program',
+      lastmod: today,
+      changefreq: 'weekly',
+      priority: '0.9'
+    },
+    {
+      url: 'https://gsdat.work/methodology',
+      lastmod: today,
+      changefreq: 'weekly',
+      priority: '0.9'
+    },
+    {
+      url: 'https://gsdat.work/triple-a-transformation',
       lastmod: today,
       changefreq: 'weekly',
       priority: '0.9'

--- a/src/pages/AssociateProgram.tsx
+++ b/src/pages/AssociateProgram.tsx
@@ -114,11 +114,13 @@ const AssociateProgram = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <KeywordOptimizedSEO 
+      <KeywordOptimizedSEO
         title="Associate Program - Join Our AI Transformation Network | GSD at Work"
         content="Become a GSD at Work associate. Deliver AI transformations, earn outcome-based compensation, maintain flexibility. Clear path from associate to principal to spin-off CEO. Apply today."
         canonicalUrl="https://gsdat.work/associate-program"
         pageType="service"
+        datePublished={currentDate}
+        dateModified={currentDate}
         structuredData={[serviceStructuredData, faqStructuredData]}
         ogType="website"
         ogImage="https://gsdat.work/og-image.png"

--- a/src/pages/methodology/index.tsx
+++ b/src/pages/methodology/index.tsx
@@ -136,11 +136,13 @@ const Methodology = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <KeywordOptimizedSEO 
+      <KeywordOptimizedSEO
         title="Open Source AI Methodologies - Free Frameworks | GSD at Work"
         content="Access battle-tested AI transformation methodologies for free. Triple-A framework, AI Oracle system, and team productivity frameworks. Enable permissionless learning and accelerate your AI journey."
         canonicalUrl="https://gsdat.work/methodology"
         pageType="service"
+        datePublished={currentDate}
+        dateModified={currentDate}
         structuredData={[serviceStructuredData]}
         ogType="website"
         ogImage="https://gsdat.work/og-image.png"


### PR DESCRIPTION
## Summary
- link sitemap in robots.txt
- add associate program and methodology pages to sitemap generator and output
- surface page freshness metadata for associate program and methodology pages

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run test:seo` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_b_68aca6f2986883338893d5ffa71ce190