### PR TITLE
Reorder Associate Program CTA and improve button contrast

### DIFF
--- a/src/pages/AssociateProgram.tsx
+++ b/src/pages/AssociateProgram.tsx
@@ -154,31 +154,6 @@ const AssociateProgram = () => {
               associate to principal to CEO.
             </p>
             
-            <div className="glass-effect border border-emerald-200/50 rounded-2xl p-8 mb-8 max-w-2xl mx-auto shadow-xl animate-fade-in-up animation-delay-300 hover:shadow-2xl hover:scale-[1.02] transition-all duration-300">
-              <p className="text-lg font-semibold text-emerald-900 mb-2">
-                💰 Performance-Based Compensation
-              </p>
-              <p className="text-emerald-800">
-                No wages, no timesheets. Earn based on the value you deliver.
-                Top performers lead teams and spin-off companies.
-              </p>
-              <Button
-                asChild
-                size="sm"
-                className={`${buttonStyles.outline.primary} ${shadows.buttonEffect} mt-4 hover:scale-105 transition-transform duration-300`}
-              >
-                <a
-                  href="https://arlos.pro"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center"
-                >
-                  Learn about our compensation philosophy
-                  <ExternalLink className="ml-1 h-4 w-4" />
-                </a>
-              </Button>
-            </div>
-
             <div className="flex flex-col sm:flex-row gap-4 justify-center animate-fade-in-up animation-delay-400">
               <Button
                 size="lg"
@@ -195,6 +170,31 @@ const AssociateProgram = () => {
                 onClick={() => window.location.href = "/methodology"}
               >
                 Study Our Methods First
+              </Button>
+            </div>
+
+            <div className="glass-effect border border-emerald-200/50 rounded-2xl p-8 mt-8 max-w-2xl mx-auto shadow-xl animate-fade-in-up animation-delay-300 hover:shadow-2xl hover:scale-[1.02] transition-all duration-300">
+              <p className="text-lg font-semibold text-emerald-900 mb-2">
+                💰 Performance-Based Compensation
+              </p>
+              <p className="text-emerald-800">
+                No wages, no timesheets. Earn based on the value you deliver.
+                Top performers lead teams and spin-off companies.
+              </p>
+              <Button
+                asChild
+                size="sm"
+                className={`${buttonStyles.primary} ${shadows.buttonEffect} mt-4 hover:scale-105 transition-transform duration-300`}
+              >
+                <a
+                  href="https://arlos.pro"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center"
+                >
+                  Learn about our compensation philosophy
+                  <ExternalLink className="ml-1 h-4 w-4" />
+                </a>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Place Apply and Study buttons above compensation info on Associate Program page
- Update compensation philosophy link to use primary button style for better contrast

## Testing
- `npm run lint`
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68b30b8014448333a50e36230994a93c