### PR TITLE
Add industry pages and evidence hub with SEO and navigation updates

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,73 +3,103 @@
   
   <url>
     <loc>https://gsdat.work/</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://gsdat.work/cases</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-tooling-report</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/10x-executive</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-action-workshop</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-legal-workshop</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-automation-integration</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/associate-program</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/methodology</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/triple-a-transformation</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://gsdat.work/industries/law-firms</loc>
+    <lastmod>2025-09-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gsdat.work/industries/manufacturing</loc>
+    <lastmod>2025-09-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gsdat.work/industries/energy</loc>
+    <lastmod>2025-09-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gsdat.work/industries/financial-services</loc>
+    <lastmod>2025-09-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://gsdat.work/evidence</loc>
+    <lastmod>2025-09-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://gsdat.work/blog</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/qualitative-data-insights-workshop</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-09-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/public/sitemap.xml.cjs
+++ b/public/sitemap.xml.cjs
@@ -110,8 +110,38 @@ const generateSitemap = () => {
       changefreq: 'weekly',
       priority: '0.9'
     },
-    { 
-      url: 'https://gsdat.work/blog', 
+    {
+      url: 'https://gsdat.work/industries/law-firms',
+      lastmod: today,
+      changefreq: 'weekly',
+      priority: '0.8'
+    },
+    {
+      url: 'https://gsdat.work/industries/manufacturing',
+      lastmod: today,
+      changefreq: 'weekly',
+      priority: '0.8'
+    },
+    {
+      url: 'https://gsdat.work/industries/energy',
+      lastmod: today,
+      changefreq: 'weekly',
+      priority: '0.8'
+    },
+    {
+      url: 'https://gsdat.work/industries/financial-services',
+      lastmod: today,
+      changefreq: 'weekly',
+      priority: '0.8'
+    },
+    {
+      url: 'https://gsdat.work/evidence',
+      lastmod: today,
+      changefreq: 'monthly',
+      priority: '0.7'
+    },
+    {
+      url: 'https://gsdat.work/blog',
       lastmod: today,
       changefreq: 'weekly',
       priority: '0.9'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,11 @@ const SalesDiscovery = lazy(() => import("./pages/methodology/SalesDiscovery"));
 const ActionWorkshop = lazy(() => import("./pages/methodology/ActionWorkshop"));
 const AIOracle = lazy(() => import("./pages/methodology/AIOracle"));
 const AssociateProgram = lazy(() => import("./pages/AssociateProgram"));
+const LawFirms = lazy(() => import("./pages/industries/law-firms"));
+const Manufacturing = lazy(() => import("./pages/industries/manufacturing"));
+const Energy = lazy(() => import("./pages/industries/energy"));
+const FinancialServices = lazy(() => import("./pages/industries/financial-services"));
+const Evidence = lazy(() => import("./pages/evidence"));
 
 const queryClient = new QueryClient();
 
@@ -74,6 +79,11 @@ const App = () => (
               <Route path="/ai-automation-integration" element={<AIAutomationIntegration />} />
               <Route path="/triple-a-transformation" element={<TripleATransformation />} />
               <Route path="/strategy-session-confirmed" element={<StrategySessionConfirmed />} />
+              <Route path="/industries/law-firms" element={<LawFirms />} />
+              <Route path="/industries/manufacturing" element={<Manufacturing />} />
+              <Route path="/industries/energy" element={<Energy />} />
+              <Route path="/industries/financial-services" element={<FinancialServices />} />
+              <Route path="/evidence" element={<Evidence />} />
               <Route path="/blog" element={<BlogPage />} />
               <Route path="/blog/:id" element={<BlogPostPage />} />
               <Route path="/not-found" element={<NotFound />} />

--- a/src/components/EnhancedFooter.tsx
+++ b/src/components/EnhancedFooter.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Phone, MessageSquare, Linkedin, ArrowRight, ExternalLink } from "lucide-react";
+import { MessageSquare, Linkedin, ArrowRight, ExternalLink } from "lucide-react";
 import { Separator } from "./ui/separator";
 
 export const EnhancedFooter = () => {
@@ -14,10 +14,17 @@ export const EnhancedFooter = () => {
       { name: "Triple-A Transformation", href: "/triple-a-transformation", description: "Complete organizational AI adoption" },
       { name: "AI Oracle Session", href: "/ai-oracle-session", description: "Executive intelligence system" },
     ],
+    industries: [
+      { name: "AI for Law Firms", href: "/industries/law-firms", description: "Secure legal workflows" },
+      { name: "AI in Manufacturing", href: "/industries/manufacturing", description: "Operational efficiency" },
+      { name: "AI for Energy", href: "/industries/energy", description: "Data-driven operations" },
+      { name: "AI in Financial Services", href: "/industries/financial-services", description: "Compliance and automation" },
+    ],
     resources: [
       { name: "AI Tooling Report", href: "/ai-tooling-report", description: "2025 implementation guide" },
       { name: "Professional Insights", href: "/blog", description: "Expert AI implementation blog" },
       { name: "Case Studies", href: "/cases", description: "Real-world success stories" },
+      { name: "Evidence", href: "/evidence", description: "Proof of outcomes" },
       { name: "Free Consultation", href: "https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call", external: true, description: "Schedule your strategy session" },
     ],
     company: [
@@ -31,7 +38,7 @@ export const EnhancedFooter = () => {
     <footer className="bg-gradient-to-br from-gray-50 to-white border-t border-gray-200" itemScope itemType="https://schema.org/WPFooter">
       <div className="container mx-auto px-4 py-16">
         {/* Main Footer Content */}
-        <div className="grid md:grid-cols-4 gap-8 mb-12">
+        <div className="grid md:grid-cols-5 gap-8 mb-12">
           {/* Company Info */}
           <div className="md:col-span-1">
             <div className="mb-6">
@@ -44,8 +51,8 @@ export const EnhancedFooter = () => {
                 <span className="text-xl font-bold text-primary">at Work</span>
               </Link>
             </div>
-            <p className="text-gray-600 mb-6 leading-relaxed">
-              Expert AI consulting and implementation services. From insight to action in minutes, not months.
+            <p className="text-sm text-muted-foreground mb-6">
+              AI adoption and implementation for law firms, manufacturing, energy, and financial services.
             </p>
             
             {/* Contact Info */}
@@ -66,6 +73,27 @@ export const EnhancedFooter = () => {
             <h3 className="text-lg font-semibold text-primary mb-4">Services</h3>
             <nav className="space-y-3">
               {navigationLinks.services.map((link) => (
+                <div key={link.name}>
+                  <Link
+                    to={link.href}
+                    className="group flex items-start hover:text-secondary transition-colors"
+                  >
+                    <ArrowRight className="h-3 w-3 mt-1 mr-2 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <div>
+                      <div className="font-medium">{link.name}</div>
+                      <div className="text-xs text-gray-500">{link.description}</div>
+                    </div>
+                  </Link>
+                </div>
+              ))}
+            </nav>
+          </div>
+
+          {/* Industries */}
+          <div>
+            <h3 className="text-lg font-semibold text-primary mb-4">Industries</h3>
+            <nav className="space-y-3">
+              {navigationLinks.industries.map((link) => (
                 <div key={link.name}>
                   <Link
                     to={link.href}

--- a/src/components/navigation/DesktopNavigation.tsx
+++ b/src/components/navigation/DesktopNavigation.tsx
@@ -233,7 +233,33 @@ export const DesktopNavigation = () => {
               </ul>
             </NavigationMenuContent>
           </NavigationMenuItem>
-          
+
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Industries</NavigationMenuTrigger>
+            <NavigationMenuContent className="bg-white">
+              <ul className="grid w-[300px] gap-3 p-4">
+                {[
+                  { href: "/industries/law-firms", title: "AI for Law Firms", desc: "Secure legal workflows" },
+                  { href: "/industries/manufacturing", title: "AI in Manufacturing", desc: "Operational efficiency" },
+                  { href: "/industries/energy", title: "AI for Energy", desc: "Data-driven operations" },
+                  { href: "/industries/financial-services", title: "AI in Financial Services", desc: "Compliance and automation" },
+                ].map((item) => (
+                  <li key={item.href}>
+                    <NavigationMenuLink asChild>
+                      <Link
+                        to={item.href}
+                        className={`block select-none space-y-1 ${borderRadius.md} p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground`}
+                      >
+                        <div className="text-sm font-medium leading-none">{item.title}</div>
+                        <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">{item.desc}</p>
+                      </Link>
+                    </NavigationMenuLink>
+                  </li>
+                ))}
+              </ul>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+
           <NavigationMenuItem>
             <NavigationMenuLink asChild>
               <Link to="/associate-program" className={navigationMenuTriggerStyle()}>

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -57,6 +57,18 @@ export const MobileNavigation = () => {
               <Link to="/triple-a-transformation" className="text-lg font-medium">
                 Triple-A Transformation
               </Link>
+              <Link to="/industries/law-firms" className="text-lg font-medium">
+                AI for Law Firms
+              </Link>
+              <Link to="/industries/manufacturing" className="text-lg font-medium">
+                AI in Manufacturing
+              </Link>
+              <Link to="/industries/energy" className="text-lg font-medium">
+                AI for Energy
+              </Link>
+              <Link to="/industries/financial-services" className="text-lg font-medium">
+                AI in Financial Services
+              </Link>
               <Link to="/cases" className="text-lg font-medium">
                 Case Studies
               </Link>

--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -91,6 +91,40 @@ export const generateOrganizationStructuredData = () => {
       "contactType": "customer service",
       "email": "hello@gsdat.work",
       "availableLanguage": "English"
+    },
+    hasOfferCatalog: {
+      "@type": "OfferCatalog",
+      "name": "AI Services",
+      "itemListElement": [
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI Action Workshop", "url": "https://gsdat.work/ai-action-workshop" }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI Oracle Session", "url": "https://gsdat.work/ai-oracle-session" }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI Automation & Integration", "url": "https://gsdat.work/ai-automation-integration" }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI for Law Firms", "url": "https://gsdat.work/industries/law-firms" }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI in Manufacturing", "url": "https://gsdat.work/industries/manufacturing" }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI for Energy", "url": "https://gsdat.work/industries/energy" }
+        },
+        {
+          "@type": "Offer",
+          "itemOffered": { "@type": "Service", "name": "AI in Financial Services", "url": "https://gsdat.work/industries/financial-services" }
+        }
+      ]
     }
   };
 };

--- a/src/pages/evidence.tsx
+++ b/src/pages/evidence.tsx
@@ -1,0 +1,28 @@
+import { SEOHead } from "@/components/SEOHead";
+import { generateOrganizationStructuredData } from "@/lib/seo-utils";
+
+const Evidence = () => {
+  const structuredData = [generateOrganizationStructuredData()];
+
+  return (
+    <>
+      <SEOHead
+        title="Evidence"
+        description="Awards, partner highlights, and fast facts about GSD at Work."
+        canonicalUrl="/evidence"
+        structuredData={structuredData}
+      />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">Evidence</h1>
+        <p className="mb-4">Proof of our AI implementations and industry partnerships.</p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Trusted by over 50 organizations worldwide</li>
+          <li>Partnered with leading AI vendors</li>
+          <li>Speaker at top industry events</li>
+        </ul>
+      </main>
+    </>
+  );
+};
+
+export default Evidence;

--- a/src/pages/industries/energy.tsx
+++ b/src/pages/industries/energy.tsx
@@ -1,0 +1,41 @@
+import { SEOHead } from "@/components/SEOHead";
+import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
+
+const Energy = () => {
+  const structuredData = [
+    generateServicePageStructuredData(
+      "AI for Energy",
+      "AI deployment for energy production, grid management, and sustainability initiatives.",
+      "https://gsdat.work/industries/energy",
+      undefined,
+      "GSD at Work",
+      "$4999"
+    ),
+    generateFAQStructuredData([
+      { question: "Do you work with renewable operators?", answer: "Yes, we optimize solar, wind, and storage assets with predictive analytics." },
+      { question: "How do you improve grid reliability?", answer: "Machine learning forecasts demand and balances load across resources." }
+    ])
+  ];
+
+  return (
+    <>
+      <SEOHead
+        title="AI for Energy"
+        description="AI deployment for energy production, grid management, and sustainability initiatives."
+        canonicalUrl="/industries/energy"
+        structuredData={structuredData}
+      />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">AI for Energy</h1>
+        <p className="mb-4">We apply AI to forecast demand, optimize assets, and support safer, cleaner energy operations.</p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Precise demand forecasting and load balancing</li>
+          <li>Asset performance optimization</li>
+          <li>Enhanced safety and regulatory compliance</li>
+        </ul>
+      </main>
+    </>
+  );
+};
+
+export default Energy;

--- a/src/pages/industries/financial-services.tsx
+++ b/src/pages/industries/financial-services.tsx
@@ -1,0 +1,41 @@
+import { SEOHead } from "@/components/SEOHead";
+import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
+
+const FinancialServices = () => {
+  const structuredData = [
+    generateServicePageStructuredData(
+      "AI in Financial Services",
+      "Regulatory-compliant AI for risk analysis, customer service, and operational efficiency.",
+      "https://gsdat.work/industries/financial-services",
+      undefined,
+      "GSD at Work",
+      "$4999"
+    ),
+    generateFAQStructuredData([
+      { question: "How do you address compliance?", answer: "We build transparent models and maintain audit trails to meet regulatory standards." },
+      { question: "What problems do you tackle first?", answer: "Risk scoring, fraud detection, and automated client support deliver quick wins." }
+    ])
+  ];
+
+  return (
+    <>
+      <SEOHead
+        title="AI in Financial Services"
+        description="Regulatory-compliant AI for risk analysis, customer service, and operational efficiency."
+        canonicalUrl="/industries/financial-services"
+        structuredData={structuredData}
+      />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">AI in Financial Services</h1>
+        <p className="mb-4">We deliver compliant AI solutions that enhance decision-making and customer experiences.</p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Automated compliance and reporting workflows</li>
+          <li>Fraud detection and risk assessment</li>
+          <li>Personalized customer insights</li>
+        </ul>
+      </main>
+    </>
+  );
+};
+
+export default FinancialServices;

--- a/src/pages/industries/law-firms.tsx
+++ b/src/pages/industries/law-firms.tsx
@@ -1,0 +1,41 @@
+import { SEOHead } from "@/components/SEOHead";
+import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
+
+const LawFirms = () => {
+  const structuredData = [
+    generateServicePageStructuredData(
+      "AI for Law Firms",
+      "Secure AI implementation for litigation, research, and intake workflows.",
+      "https://gsdat.work/industries/law-firms",
+      undefined,
+      "GSD at Work",
+      "$4999"
+    ),
+    generateFAQStructuredData([
+      { question: "How do you handle confidentiality?", answer: "We implement org-scoped models, DLP, and redaction to protect sensitive data." },
+      { question: "What are typical first steps?", answer: "Discovery, policy development, proof of concept in intake or research, and training." }
+    ])
+  ];
+
+  return (
+    <>
+      <SEOHead
+        title="AI for Law Firms"
+        description="Secure AI implementation for legal workflows—intake, research, drafting."
+        canonicalUrl="/industries/law-firms"
+        structuredData={structuredData}
+      />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">AI for Law Firms</h1>
+        <p className="mb-4">We help law firms implement AI securely to accelerate document review, research, and client intake.</p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Reduce review times by up to 70%</li>
+          <li>Confidentiality safeguards for sensitive data</li>
+          <li>Workflow automation for intake and discovery</li>
+        </ul>
+      </main>
+    </>
+  );
+};
+
+export default LawFirms;

--- a/src/pages/industries/manufacturing.tsx
+++ b/src/pages/industries/manufacturing.tsx
@@ -1,0 +1,41 @@
+import { SEOHead } from "@/components/SEOHead";
+import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
+
+const Manufacturing = () => {
+  const structuredData = [
+    generateServicePageStructuredData(
+      "AI in Manufacturing",
+      "Industrial AI for predictive maintenance, quality control, and supply chain optimization.",
+      "https://gsdat.work/industries/manufacturing",
+      undefined,
+      "GSD at Work",
+      "$4999"
+    ),
+    generateFAQStructuredData([
+      { question: "How does AI reduce downtime?", answer: "Predictive models forecast failures and schedule maintenance before issues arise." },
+      { question: "Can you integrate with existing systems?", answer: "Yes, we connect to your MES/ERP and sensor data for seamless insights." }
+    ])
+  ];
+
+  return (
+    <>
+      <SEOHead
+        title="AI in Manufacturing"
+        description="Industrial AI for predictive maintenance, quality control, and supply chain optimization."
+        canonicalUrl="/industries/manufacturing"
+        structuredData={structuredData}
+      />
+      <main className="container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold mb-4">AI in Manufacturing</h1>
+        <p className="mb-4">We deploy AI to boost production efficiency, quality, and uptime across your operations.</p>
+        <ul className="list-disc pl-6 space-y-2">
+          <li>Predictive maintenance to cut downtime</li>
+          <li>Real-time quality inspection with vision AI</li>
+          <li>Supply chain analytics for demand planning</li>
+        </ul>
+      </main>
+    </>
+  );
+};
+
+export default Manufacturing;


### PR DESCRIPTION
## Summary
- add positioning tagline and Industries column to footer
- create law firms, manufacturing, energy, financial services, and evidence pages with structured data
- expose industry pages in navigation, routes, sitemap, and offer catalog schema

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run generate:sitemap`
- `npm run generate:rss`


------
https://chatgpt.com/codex/tasks/task_b_68c0c73fc950833392894ce1a8737be8