### PR TITLE
fix: Close mobile navigation sheet when links are clicked

### DIFF
--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -1,6 +1,7 @@
 
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Menu, Phone } from "lucide-react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -9,8 +10,14 @@ import {
 } from "@/components/ui/sheet";
 
 export const MobileNavigation = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleNavigate = () => {
+    setIsOpen(false);
+  };
+
   return (
-    <Sheet>
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
         <Button
           variant="ghost"
@@ -23,7 +30,7 @@ export const MobileNavigation = () => {
           <span className="sr-only">Open navigation menu</span>
         </Button>
       </SheetTrigger>
-        <SheetContent side="left" className="w-[300px] sm:w-[350px] bg-white p-0 flex flex-col h-full max-h-[100vh] max-h-[100dvh]">
+      <SheetContent side="left" className="w-[300px] sm:w-[350px] bg-white p-0 flex flex-col h-full max-h-[100vh] max-h-[100dvh]">
         <div className="flex flex-col h-full overflow-hidden">
           <div className="flex-shrink-0 flex flex-col items-center justify-center pt-12 pb-8">
             <img 
@@ -36,43 +43,43 @@ export const MobileNavigation = () => {
           
           <div className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain [-webkit-overflow-scrolling:touch] px-6">
             <div className="flex flex-col space-y-6 pb-6">
-              <Link to="/" className="text-lg font-medium">
+              <Link to="/" className="text-lg font-medium" onClick={handleNavigate}>
                 Home
               </Link>
-              <Link to="/enterprise-ai-cooking-show" className="text-lg font-medium">
+              <Link to="/enterprise-ai-cooking-show" className="text-lg font-medium" onClick={handleNavigate}>
                 Enterprise AI Cooking Show
               </Link>
-              <Link to="/ai-oracle-session" className="text-lg font-medium">
+              <Link to="/ai-oracle-session" className="text-lg font-medium" onClick={handleNavigate}>
                 AI Oracle Session
               </Link>
-              <Link to="/ai-action-workshop" className="text-lg font-medium">
+              <Link to="/ai-action-workshop" className="text-lg font-medium" onClick={handleNavigate}>
                 AI Action Workshop
               </Link>
-              <Link to="/10x-executive" className="text-lg font-medium">
+              <Link to="/10x-executive" className="text-lg font-medium" onClick={handleNavigate}>
                 10x Executive Program
               </Link>
-              <Link to="/ai-automation-integration" className="text-lg font-medium">
+              <Link to="/ai-automation-integration" className="text-lg font-medium" onClick={handleNavigate}>
                 AI Automation & Integration
               </Link>
-              <Link to="/triple-a-transformation" className="text-lg font-medium">
+              <Link to="/triple-a-transformation" className="text-lg font-medium" onClick={handleNavigate}>
                 Triple-A Transformation
               </Link>
-              <Link to="/cases" className="text-lg font-medium">
+              <Link to="/cases" className="text-lg font-medium" onClick={handleNavigate}>
                 Case Studies
               </Link>
-              <Link to="/ai-tooling-report" className="text-lg font-medium">
+              <Link to="/ai-tooling-report" className="text-lg font-medium" onClick={handleNavigate}>
                 AI Tooling Report
               </Link>
-              <Link to="/methodology" className="text-lg font-medium">
+              <Link to="/methodology" className="text-lg font-medium" onClick={handleNavigate}>
                 GSD Methodologies (Open Source)
               </Link>
-              <Link to="/blog" className="text-lg font-medium">
+              <Link to="/blog" className="text-lg font-medium" onClick={handleNavigate}>
                 Professional Insights
               </Link>
-              <Link to="/hirescope" className="text-lg font-medium">
+              <Link to="/hirescope" className="text-lg font-medium" onClick={handleNavigate}>
                 HireScope (Open Source)
               </Link>
-              <Link to="/associate-program" className="text-lg font-medium">
+              <Link to="/associate-program" className="text-lg font-medium" onClick={handleNavigate}>
                 Associate Program
               </Link>
             </div>
@@ -81,7 +88,10 @@ export const MobileNavigation = () => {
           <div className="flex-shrink-0 px-6 pb-8 pt-6 flex flex-col gap-4 border-t">
             <Button
               className="w-full bg-secondary hover:bg-secondary/90 text-white py-6"
-              onClick={() => window.open("https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call", "_blank")}
+              onClick={() => {
+                window.open("https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call", "_blank");
+                handleNavigate();
+              }}
             >
               Book a Strategy Call
             </Button>


### PR DESCRIPTION
## Summary
- Added state management to control the mobile navigation sheet's open/closed state
- Implemented auto-close functionality when users click navigation links or the strategy call button
- Improves mobile UX by preventing the sheet from staying open after navigation

## Test plan
- [x] Open mobile navigation menu
- [x] Click any navigation link - sheet should close automatically
- [x] Click "Book a Strategy Call" button - sheet should close after opening external link
- [x] Test sheet can still be opened/closed manually via the menu button

🤖 Generated with [Claude Code](https://claude.ai/code)