### PR TITLE
Fix lucide icon import on ledger page to restore preview build

### DIFF
--- a/docs/LEDGER-PIPELINE.md
+++ b/docs/LEDGER-PIPELINE.md
@@ -1,0 +1,85 @@
+# Ledger of Compelling Facts – Integration Blueprint
+
+This document expands on the on-site ledger page and captures the technical decisions required to bring the public ledger online.
+
+## Source Systems
+
+| Source | Purpose | Access Method | Notes |
+| --- | --- | --- | --- |
+| Mercury Business Banking | Primary operating account that receives consolidated deposits | [Mercury API](https://mercury.com/developers/api) using a read-only token | Only ingest credits tagged as revenue; internal transfers should be ignored. |
+| Operating Checking Account | Legacy ACH/wire deposits outside of Mercury | Plaid or direct bank export (CSV) | Requires manual tagging to filter out personal/legacy transactions. |
+| Stripe | Card payments for workshops/programs | Stripe API + webhooks | Backfill historical balance transactions, then rely on `payment_intent.succeeded` events. |
+| Square | Point-of-sale and invoice payments | Square Transactions API | OAuth app with read-only scopes. Capture invoice/customer metadata. |
+| Historical Spreadsheets | Pre-Mercury ledger | Manual CSV import | Normalize column headers to `date`, `description`, `amount`, `client_alias`, and `source_document`. |
+
+## Environment Variables
+
+Add the following keys to your deployment environment (e.g., Netlify, Vercel, or Docker secrets). Keep them out of version control.
+
+```
+MERCURY_API_KEY=
+STRIPE_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+SQUARE_ACCESS_TOKEN=
+PLAID_CLIENT_ID=
+PLAID_SECRET=
+LEDGER_DATABASE_URL=
+```
+
+- `MERCURY_API_KEY`: Generate a read-only token scoped to transactions.
+- `STRIPE_API_KEY`: Restricted key with read-only permissions.
+- `STRIPE_WEBHOOK_SECRET`: For validating inbound webhook requests.
+- `SQUARE_ACCESS_TOKEN`: OAuth token with `PAYMENTS_READ` and `CUSTOMERS_READ` scopes.
+- `PLAID_CLIENT_ID` / `PLAID_SECRET`: Only required if you choose Plaid for the legacy checking account.
+- `LEDGER_DATABASE_URL`: Connection string for the warehouse (e.g., Supabase, Neon, or managed Postgres).
+
+## Ingestion Flow
+
+1. **Scheduler** – Use a cron job (GitHub Actions, Netlify Scheduled Functions, or Supabase Cron) to fetch new transactions every hour.
+2. **Normalizer** – Convert provider payloads into a shared schema:
+   ```json
+   {
+     "id": "provider-transaction-id",
+     "source": "mercury|stripe|square|checking|legacy",
+     "event_type": "inflow|adjustment|transfer",
+     "occurred_at": "ISO8601",
+     "amount": {
+       "currency": "USD",
+       "gross": 4999,
+       "net": 4870
+     },
+     "client_alias": "Atlas Manufacturing",
+     "metadata": {
+       "program": "AI Tooling Workshop",
+       "processor_fee": 129,
+       "memo": "Invoice #INV-2301"
+     }
+   }
+   ```
+3. **Deduplication** – Mark Stripe/Square derived settlements and suppress duplicates once the Mercury deposit is observed.
+4. **Review queue** – Flag each entry for manual approval before it is published to the public feed. Capture redaction rules (amount hidden vs. visible).
+5. **Publish** – Commit approved entries to a static JSON feed (`public/ledger.json`) or expose them via an API route consumed by the React page.
+
+## Evidence Management
+
+- Store transcripts, briefs, and deliverables in a secure drive (Notion, Google Drive, or Supabase Storage).
+- Record artifact metadata (type, URL, notes, permission status) alongside the ledger entry.
+- Use expiring, access-controlled links for artifacts that become public.
+
+## Roadmap Alignment
+
+The milestones exposed on `/ledger` mirror this plan:
+
+1. **Architecture blueprint** – Complete (this document + UI page).
+2. **Mercury sync** – Implement ETL job using `MERCURY_API_KEY`.
+3. **Stripe/Square webhooks** – Add webhook handler with signature verification and dedupe logic.
+4. **Public ledger alpha** – Publish vetted entries and supporting evidence.
+
+## Next Steps
+
+- Stand up the ingestion repository or serverless function.
+- Backfill historical records via Mercury CSV export and Stripe balance transactions.
+- Configure monitoring/alerting for failed syncs.
+- Iterate on redaction tooling to balance transparency with confidentiality.
+
+Once the data feed is live, the React ledger timeline can switch from static sample data to the real JSON endpoint without structural changes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ const SalesDiscovery = lazy(() => import("./pages/methodology/SalesDiscovery"));
 const ActionWorkshop = lazy(() => import("./pages/methodology/ActionWorkshop"));
 const AIOracle = lazy(() => import("./pages/methodology/AIOracle"));
 const AssociateProgram = lazy(() => import("./pages/AssociateProgram"));
+const Ledger = lazy(() => import("./pages/Ledger"));
 
 const queryClient = new QueryClient();
 
@@ -78,6 +79,7 @@ const App = () => (
               <Route path="/blog/:id" element={<BlogPostPage />} />
               <Route path="/not-found" element={<NotFound />} />
               <Route path="/associate-call-confirmed" element={<AssociateCallConfirmed />} />
+              <Route path="/ledger" element={<Ledger />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Suspense>

--- a/src/components/EnhancedFooter.tsx
+++ b/src/components/EnhancedFooter.tsx
@@ -17,6 +17,7 @@ export const EnhancedFooter = () => {
     resources: [
       { name: "AI Tooling Report", href: "/ai-tooling-report", description: "2025 implementation guide" },
       { name: "Professional Insights", href: "/blog", description: "Expert AI implementation blog" },
+      { name: "Ledger of Compelling Facts", href: "/ledger", description: "Public proof of work" },
       { name: "Case Studies", href: "/cases", description: "Real-world success stories" },
       { name: "Free Consultation", href: "https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call", external: true, description: "Schedule your strategy session" },
     ],

--- a/src/components/ledger/LedgerTimeline.tsx
+++ b/src/components/ledger/LedgerTimeline.tsx
@@ -1,0 +1,277 @@
+import { useMemo, useState } from "react";
+import { format, parseISO } from "date-fns";
+import {
+  ledgerEntries,
+  ledgerSources,
+  type LedgerEntry,
+  type LedgerSource,
+  type LedgerSourceMeta,
+} from "@/data/ledger";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Banknote,
+  Building2,
+  CalendarDays,
+  CircleDot,
+  FileText,
+  Link as LinkIcon,
+  Loader,
+  ShieldCheck,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type SourceFilter = LedgerSource | "all";
+
+const statusStyles: Record<LedgerEntry["status"], { label: string; className: string; icon: JSX.Element }> = {
+  verified: {
+    label: "Verified",
+    className: "bg-emerald-100 text-emerald-700 border-emerald-200",
+    icon: <ShieldCheck className="h-3.5 w-3.5" />,
+  },
+  pending: {
+    label: "Pending",
+    className: "bg-amber-100 text-amber-700 border-amber-200",
+    icon: <Loader className="h-3.5 w-3.5 animate-spin" />,
+  },
+  draft: {
+    label: "Draft",
+    className: "bg-slate-200 text-slate-700 border-slate-200",
+    icon: <CircleDot className="h-3.5 w-3.5" />,
+  },
+};
+
+const sourceMetaMap = Object.fromEntries(ledgerSources.map((source) => [source.id, source]));
+
+const sourceIcon: Record<LedgerSource, JSX.Element> = {
+  mercury: <Banknote className="h-4 w-4" />,
+  checking: <Building2 className="h-4 w-4" />,
+  stripe: <Banknote className="h-4 w-4" />,
+  square: <Banknote className="h-4 w-4" />,
+  legacy: <FileText className="h-4 w-4" />,
+};
+
+const entryTypeCopy: Record<NonNullable<LedgerEntry["entryType"]>, string> = {
+  inflow: "Revenue Inflow",
+  adjustment: "Adjustment",
+  transfer: "Transfer",
+};
+
+const integrationStatusMeta: Record<LedgerSourceMeta["integrationStatus"], { label: string; icon: JSX.Element }> = {
+  "not-started": {
+    label: "Not started",
+    icon: <CircleDot className="h-4 w-4 text-slate-400" />,
+  },
+  "in-progress": {
+    label: "In progress",
+    icon: <Loader className="h-4 w-4 animate-spin text-secondary" />,
+  },
+  live: {
+    label: "Live",
+    icon: <ShieldCheck className="h-4 w-4 text-emerald-500" />,
+  },
+};
+
+const formatAmount = (entry: LedgerEntry) => {
+  if (!entry.amount || !entry.currency || !entry.isAmountPublic) {
+    return "Amount redacted";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: entry.currency,
+    maximumFractionDigits: 0,
+  }).format(entry.amount);
+};
+
+export const LedgerTimeline = () => {
+  const [activeSource, setActiveSource] = useState<SourceFilter>("all");
+
+  const entriesByYear = useMemo(() => {
+    const filtered = ledgerEntries
+      .filter((entry) => activeSource === "all" || entry.source === activeSource)
+      .sort((a, b) => parseISO(b.date).getTime() - parseISO(a.date).getTime());
+
+    return filtered.reduce<Record<string, LedgerEntry[]>>((acc, entry) => {
+      const year = format(parseISO(entry.date), "yyyy");
+      if (!acc[year]) {
+        acc[year] = [];
+      }
+      acc[year].push(entry);
+      return acc;
+    }, {});
+  }, [activeSource]);
+
+  const sourceFilters: { id: SourceFilter; label: string }[] = [
+    { id: "all", label: "All Sources" },
+    ...ledgerSources.map((source) => ({ id: source.id, label: source.name })),
+  ];
+
+  return (
+    <div className="space-y-12">
+      <Card className="border border-slate-200 shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold">Source Filters</CardTitle>
+          <CardDescription>
+            Toggle data sources to understand what is currently represented in the ledger timeline.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          {sourceFilters.map((filter) => (
+            <Button
+              key={filter.id}
+              variant={activeSource === filter.id ? "default" : "outline"}
+              className={cn(
+                "rounded-full",
+                activeSource === filter.id ? "bg-secondary hover:bg-secondary/90 text-white" : "border-slate-200"
+              )}
+              onClick={() => setActiveSource(filter.id)}
+            >
+              {filter.id !== "all" && sourceIcon[filter.id]}
+              <span className={cn(filter.id !== "all" ? "ml-2" : "")}>{filter.label}</span>
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="space-y-8">
+        {Object.entries(entriesByYear).length === 0 ? (
+          <Card className="border border-dashed border-slate-200 text-center py-16">
+            <CardHeader className="items-center">
+              <CardTitle className="text-xl">No entries yet</CardTitle>
+              <CardDescription className="max-w-md">
+                Add transactions for the selected source to populate the ledger timeline. Once sources sync, they will appear here
+.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          Object.entries(entriesByYear)
+            .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))
+            .map(([year, entries]) => (
+              <section key={year} className="space-y-4">
+                <div className="flex items-center gap-3">
+                  <div className="h-px flex-1 bg-gradient-to-r from-secondary/40 via-secondary/60 to-transparent" />
+                  <Badge className="bg-secondary/20 text-secondary border-0 px-4 py-1 text-sm">{year}</Badge>
+                  <div className="h-px flex-1 bg-gradient-to-l from-secondary/40 via-secondary/60 to-transparent" />
+                </div>
+                <div className="space-y-6">
+                  {entries.map((entry) => {
+                    const meta = sourceMetaMap[entry.source];
+                    const status = statusStyles[entry.status];
+
+                    return (
+                      <Card key={entry.id} className="border border-slate-200 shadow-sm">
+                        <CardHeader className="space-y-3">
+                          <div className="flex flex-wrap items-center gap-3">
+                            <Badge className={cn("flex items-center gap-2 border", status.className)}>
+                              {status.icon}
+                              <span>{status.label}</span>
+                            </Badge>
+                            {entry.entryType && (
+                              <Badge variant="outline" className="border-secondary/20 text-secondary bg-secondary/10">
+                                {entryTypeCopy[entry.entryType]}
+                              </Badge>
+                            )}
+                            <Badge variant="outline" className="border-slate-200 text-slate-600 bg-white">
+                              <div className="flex items-center gap-2">
+                                {sourceIcon[entry.source]}
+                                <span>{meta?.name ?? entry.source}</span>
+                              </div>
+                            </Badge>
+                          </div>
+
+                          <CardTitle className="text-xl font-semibold">{entry.clientAlias}</CardTitle>
+                          <CardDescription className="text-base text-slate-600">
+                            {entry.summary}
+                          </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                          <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+                            <div className="flex items-center gap-2">
+                              <CalendarDays className="h-4 w-4" />
+                              <span>{format(parseISO(entry.date), "MMMM d, yyyy")}</span>
+                            </div>
+                            <Separator orientation="vertical" className="h-5" />
+                            <div className="flex items-center gap-2">
+                              <Banknote className="h-4 w-4" />
+                              <span>{formatAmount(entry)}</span>
+                            </div>
+                            {meta?.integrationStatus && (
+                              <>
+                                <Separator orientation="vertical" className="h-5" />
+                                <div className="flex items-center gap-2">
+                                  {integrationStatusMeta[meta.integrationStatus].icon}
+                                  <span>{`Source sync: ${integrationStatusMeta[meta.integrationStatus].label}`}</span>
+                                </div>
+                              </>
+                            )}
+                          </div>
+
+                          {entry.tags && entry.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-2">
+                              {entry.tags.map((tag) => (
+                                <Badge key={tag} variant="secondary" className="bg-primary/10 text-primary border-0">
+                                  #{tag}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+
+                          {entry.artifacts && entry.artifacts.length > 0 && (
+                            <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-4">
+                              <h4 className="text-sm font-semibold text-slate-700 mb-3 flex items-center gap-2">
+                                <FileText className="h-4 w-4" /> Supporting Materials
+                              </h4>
+                              <ScrollArea className="max-h-48 pr-4">
+                                <ul className="space-y-3 text-sm text-slate-600">
+                                  {entry.artifacts.map((artifact, index) => (
+                                    <li key={`${entry.id}-artifact-${index}`} className="flex items-start gap-3">
+                                      <LinkIcon className="h-4 w-4 mt-0.5 text-secondary" />
+                                      <div>
+                                        <p className="font-medium text-slate-700">{artifact.label}</p>
+                                        {artifact.url ? (
+                                          <a
+                                            href={artifact.url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-secondary hover:underline"
+                                          >
+                                            View primary source
+                                          </a>
+                                        ) : (
+                                          <p className="text-xs text-slate-500">Link coming soon</p>
+                                        )}
+                                        {artifact.notes && (
+                                          <p className="text-xs text-slate-500 mt-1">{artifact.notes}</p>
+                                        )}
+                                      </div>
+                                    </li>
+                                  ))}
+                                </ul>
+                              </ScrollArea>
+                            </div>
+                          )}
+
+                          {entry.notes && (
+                            <p className="text-sm text-slate-500 bg-amber-50/80 border border-amber-100 rounded-lg p-4">
+                              {entry.notes}
+                            </p>
+                          )}
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </div>
+              </section>
+            ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LedgerTimeline;

--- a/src/components/navigation/DesktopNavigation.tsx
+++ b/src/components/navigation/DesktopNavigation.tsx
@@ -196,6 +196,19 @@ export const DesktopNavigation = () => {
                 </li>
                 <li>
                   <NavigationMenuLink asChild>
+                    <Link
+                      to="/ledger"
+                      className={`block select-none space-y-1 ${borderRadius.md} p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground`}
+                    >
+                      <div className="text-sm font-medium leading-none">Ledger of Compelling Facts</div>
+                      <p className="line-clamp-2 text-sm leading-snug text-muted-foreground mt-1">
+                        Timeline of capital inflows and supporting evidence
+                      </p>
+                    </Link>
+                  </NavigationMenuLink>
+                </li>
+                <li>
+                  <NavigationMenuLink asChild>
                     <Link to="/methodology"
                       className={`block select-none space-y-1 ${borderRadius.md} p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground`}
                     >

--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -67,6 +67,9 @@ export const MobileNavigation = () => {
               <Link to="/cases" className="text-lg font-medium" onClick={handleNavigate}>
                 Case Studies
               </Link>
+              <Link to="/ledger" className="text-lg font-medium" onClick={handleNavigate}>
+                Ledger of Compelling Facts
+              </Link>
               <Link to="/ai-tooling-report" className="text-lg font-medium" onClick={handleNavigate}>
                 AI Tooling Report
               </Link>

--- a/src/data/ledger.ts
+++ b/src/data/ledger.ts
@@ -1,0 +1,213 @@
+export type LedgerSource = "mercury" | "checking" | "stripe" | "square" | "legacy";
+
+export interface LedgerArtifact {
+  label: string;
+  url?: string;
+  type?: "transcript" | "email" | "document" | "automation-log" | "note";
+  notes?: string;
+}
+
+export interface LedgerEntry {
+  id: string;
+  date: string; // ISO 8601 string
+  source: LedgerSource;
+  clientAlias: string;
+  summary: string;
+  amount?: number;
+  currency?: string;
+  isAmountPublic?: boolean;
+  tags?: string[];
+  status: "verified" | "pending" | "draft";
+  entryType?: "inflow" | "adjustment" | "transfer";
+  artifacts?: LedgerArtifact[];
+  notes?: string;
+}
+
+export interface LedgerSourceMeta {
+  id: LedgerSource;
+  name: string;
+  description: string;
+  integrationStatus: "not-started" | "in-progress" | "live";
+  syncStrategy: string;
+  visibilityNotes?: string;
+  lastSyncedAt?: string;
+}
+
+export const ledgerSources: LedgerSourceMeta[] = [
+  {
+    id: "mercury",
+    name: "Mercury Business Banking",
+    description:
+      "Primary operating account capturing consolidated revenue deposits and settlements from payment processors.",
+    integrationStatus: "in-progress",
+    syncStrategy:
+      "Use Mercury API with read-only token scoped to transactions endpoint. Mirror deposits tagged as revenue inflows while ignoring internal transfers.",
+    visibilityNotes:
+      "Some deposits are already roll-ups from Stripe or Square. Requires deduplication logic before publishing entries.",
+    lastSyncedAt: "2025-02-15T15:30:00Z",
+  },
+  {
+    id: "checking",
+    name: "Operating Checking Account",
+    description:
+      "Legacy checking account that receives direct ACH and wire payments from clients who do not use card processors.",
+    integrationStatus: "not-started",
+    syncStrategy:
+      "Explore Plaid or direct bank API export. Fallback: secure CSV export with manual review before ingestion into ledger pipeline.",
+    visibilityNotes:
+      "Contains both business and legacy transactions. Needs tagging workflow before entries can be shared publicly.",
+  },
+  {
+    id: "stripe",
+    name: "Stripe",
+    description:
+      "Handles card transactions for productized services and workshops.",
+    integrationStatus: "in-progress",
+    syncStrategy:
+      "Webhook listener for `payment_intent.succeeded` and scheduled backfill job using Stripe Balance Transaction API to reconcile fees and settlements.",
+  },
+  {
+    id: "square",
+    name: "Square",
+    description:
+      "Point-of-sale and invoice payments for on-site activations and legacy clients.",
+    integrationStatus: "not-started",
+    syncStrategy:
+      "Square Transactions API with OAuth. Capture payment, customer reference, and location metadata for contextual timeline entries.",
+  },
+  {
+    id: "legacy",
+    name: "Pre-Mercury Historical Ledger",
+    description:
+      "Spreadsheet exports and notebooks from the early business phase before the dedicated Mercury account existed.",
+    integrationStatus: "not-started",
+    syncStrategy:
+      "Manual migration: normalize existing spreadsheets into CSV, enrich with client aliases, and import through ledger ingestion script.",
+    visibilityNotes:
+      "Some entries pre-date formal NDAs; require case-by-case approval before making public.",
+  },
+];
+
+export const ledgerEntries: LedgerEntry[] = [
+  {
+    id: "2025-merc-jan-automation-sprint",
+    date: "2025-01-12",
+    source: "mercury",
+    clientAlias: "GrowthOps Collective",
+    summary:
+      "Deposit from GrowthOps Collective for AI Automation Sprint focused on marketing attribution pipeline overhaul.",
+    amount: 12500,
+    currency: "USD",
+    isAmountPublic: false,
+    tags: ["ai-automation", "marketing-ops", "sprint"],
+    status: "verified",
+    entryType: "inflow",
+    artifacts: [
+      {
+        label: "Engagement kickoff transcript",
+        type: "transcript",
+        notes: "Zoom transcript stored in Notion workspace. Ready for redaction pending client approval.",
+      },
+      {
+        label: "Automation architecture diagram",
+        type: "document",
+        url: "https://example.com/automation-architecture",
+      },
+    ],
+    notes:
+      "Matches Stripe settlement batch STRIPE-SET-8841. Need to suppress duplicate entry once processor level timeline is live.",
+  },
+  {
+    id: "2024-stripe-dec-tooling-report",
+    date: "2024-12-05",
+    source: "stripe",
+    clientAlias: "Atlas Manufacturing",
+    summary:
+      "Stripe payment for 2025 AI Tooling & Budget workshop facilitation including executive briefing deck.",
+    amount: 4999,
+    currency: "USD",
+    isAmountPublic: true,
+    tags: ["workshop", "tooling-report", "executive"],
+    status: "verified",
+    entryType: "inflow",
+    artifacts: [
+      {
+        label: "Workshop agenda",
+        type: "document",
+        url: "https://example.com/ai-tooling-agenda",
+      },
+      {
+        label: "Client testimonial request",
+        type: "email",
+        notes: "Awaiting approval to publish clip on ledger page.",
+      },
+    ],
+  },
+  {
+    id: "2023-square-summit",
+    date: "2023-08-22",
+    source: "square",
+    clientAlias: "Summit Retreats",
+    summary:
+      "Square invoice payment for on-site AI adoption training during leadership offsite.",
+    tags: ["training", "onsite", "legacy"],
+    status: "pending",
+    entryType: "inflow",
+    artifacts: [
+      {
+        label: "Legacy invoice PDF",
+        type: "document",
+        notes: "Stored in Google Drive. Needs migration to central ledger storage.",
+      },
+    ],
+    notes:
+      "Amount withheld until reconciliation confirms final payout after Square fees. Add currency once records are normalized.",
+  },
+];
+
+export interface LedgerRoadmapItem {
+  id: string;
+  milestone: string;
+  status: "complete" | "in-progress" | "up-next";
+  targetDate?: string;
+  description: string;
+  dependencies?: string[];
+}
+
+export const ledgerRoadmap: LedgerRoadmapItem[] = [
+  {
+    id: "architecture-blueprint",
+    milestone: "Define ledger architecture and publishing workflow",
+    status: "complete",
+    targetDate: "2025-02-10",
+    description:
+      "Documented ingestion pipeline, source systems, and redaction strategy for the public ledger (this page).",
+  },
+  {
+    id: "mercury-sync",
+    milestone: "Stand up Mercury API sync job",
+    status: "in-progress",
+    targetDate: "2025-03-01",
+    description:
+      "Provision read-only API token, implement scheduled pull into internal warehouse, and flag deposits requiring duplicate suppression.",
+    dependencies: ["architecture-blueprint"],
+  },
+  {
+    id: "stripe-webhooks",
+    milestone: "Launch Stripe + Square processor listeners",
+    status: "up-next",
+    targetDate: "2025-03-20",
+    description:
+      "Configure webhook relays capturing invoice/customer metadata and link to supporting transcripts or deliverables.",
+    dependencies: ["mercury-sync"],
+  },
+  {
+    id: "public-ledger-alpha",
+    milestone: "Publish first public ledger entries",
+    status: "up-next",
+    targetDate: "2025-04-05",
+    description:
+      "Ship read-only timeline with curated entries, client-approved aliases, and optional evidence links.",
+    dependencies: ["stripe-webhooks"],
+  },
+];

--- a/src/pages/Ledger.tsx
+++ b/src/pages/Ledger.tsx
@@ -1,0 +1,305 @@
+import { Layout } from "@/components/Layout";
+import { SEOHead } from "@/components/SEOHead";
+import LedgerTimeline from "@/components/ledger/LedgerTimeline";
+import { ledgerSources, ledgerRoadmap } from "@/data/ledger";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { shadows, gradients } from "@/lib/design-tokens";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Database,
+  GitBranch,
+  KeyRound,
+  Lock,
+  ShieldCheck,
+  Workflow,
+} from "lucide-react";
+
+const LedgerPage = () => {
+  const structuredData = [
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      name: "Ledger of Compelling Facts",
+      description:
+        "Programmatically generated ledger documenting revenue inflows, engagement metadata, and proof of work for GSD at Work clients.",
+      url: "https://gsdat.work/ledger",
+      breadcrumb: {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: "https://gsdat.work/",
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Ledger of Compelling Facts",
+            item: "https://gsdat.work/ledger",
+          },
+        ],
+      },
+    },
+  ];
+
+  return (
+    <Layout>
+      <SEOHead
+        title="Ledger of Compelling Facts | GSD at Work"
+        description="Follow the real-time ledger of capital inflows, engagement artifacts, and supporting primary sources that document proof of value at GSD at Work."
+        canonicalUrl="https://gsdat.work/ledger"
+        keywords="public client ledger, ai consulting proof, capital inflow timeline, GSD at Work ledger"
+        structuredData={structuredData}
+      />
+
+      <div className="relative overflow-hidden bg-slate-50">
+        <div className="absolute inset-0 bg-gradient-to-br from-secondary/10 via-white to-primary/5" aria-hidden="true" />
+        <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-28 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <Badge className="bg-secondary/20 text-secondary border-0 mb-4">Ledger of Compelling Facts</Badge>
+            <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-6xl">
+              Documenting every meaningful inflow of value
+            </h1>
+            <p className="mt-6 text-lg leading-8 text-slate-600">
+              This public-facing ledger is the system of record for the engagements and transactions that prove competence. Each entry captures the revenue inflow, the program that generated it, and the artifacts we can share once client permissions are in place.
+            </p>
+            <p className="mt-4 text-base text-slate-500">
+              The data below is a curated snapshot while the ingestion pipeline comes online. As integrations progress, the timeline will update automatically.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <section className="-mt-12 pb-24">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Card className={`${gradients.primaryLight} ${shadows.md} text-white`}>
+              <CardHeader>
+                <CardTitle className="text-2xl">Operational intent</CardTitle>
+                <CardDescription className="text-white/80">
+                  Build a verifiable, API-driven ledger that connects capital inflows to the conversations, deliverables, and transformations they created.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-white/80">
+                <div className="flex items-center gap-3">
+                  <CheckCircle2 className="h-5 w-5 text-white" />
+                  <span>Source-level ingestion with deduplication across Mercury, Stripe, Square, and legacy archives.</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <ShieldCheck className="h-5 w-5 text-white" />
+                  <span>Redaction controls to honor client confidentiality while still proving the work.</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <GitBranch className="h-5 w-5 text-white" />
+                  <span>Roadmap toward automated case-study generation by linking every entry to primary sources.</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border border-slate-200">
+              <CardHeader>
+                <CardTitle>API & data pipeline snapshot</CardTitle>
+                <CardDescription>
+                  Inventory of data sources and current integration status for the public ledger.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {ledgerSources.map((source) => (
+                  <div key={source.id} className="rounded-lg border border-slate-200 bg-white p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <h3 className="text-base font-semibold text-slate-900">{source.name}</h3>
+                        <p className="text-sm text-slate-600">{source.description}</p>
+                      </div>
+                      <Badge variant="secondary" className="bg-primary/10 text-primary border-0 capitalize">
+                        {source.integrationStatus.replace("-", " ")}
+                      </Badge>
+                    </div>
+                    <p className="mt-3 text-sm text-slate-500">{source.syncStrategy}</p>
+                    {source.visibilityNotes && (
+                      <p className="mt-2 text-xs text-amber-600">
+                        <strong className="uppercase tracking-wide">Visibility:</strong> {source.visibilityNotes}
+                      </p>
+                    )}
+                    {source.lastSyncedAt && (
+                      <p className="mt-2 text-xs text-slate-400">Last sync: {new Date(source.lastSyncedAt).toLocaleString()}</p>
+                    )}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="pb-24">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center mb-12">
+            <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20">
+              Timeline (Alpha)
+            </Badge>
+            <h2 className="mt-4 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+              Curated inflows and proof packets
+            </h2>
+            <p className="mt-4 text-lg text-slate-600">
+              Filter the data by source to see how value moved into the business. Each record links to the artifacts that will power future case studies.
+            </p>
+          </div>
+
+          <LedgerTimeline />
+        </div>
+      </section>
+
+      <section className="pb-28 bg-slate-900 text-white">
+        <div className="mx-auto max-w-6xl px-6 py-20 lg:px-8">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <Card className="bg-slate-800/70 border border-slate-700">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-white">
+                  <Database className="h-5 w-5" /> Data warehouse choreography
+                </CardTitle>
+                <CardDescription className="text-slate-300">
+                  The ledger starts with a normalized event store that merges raw transactions with contextual metadata.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-slate-200">
+                <p>Daily sync jobs land into a Postgres instance. Records are tagged with engagement IDs and settlement provenance.</p>
+                <p>Stripe and Square fees are reconciled so net and gross values can both be reported when permissions allow.</p>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-slate-800/70 border border-slate-700">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-white">
+                  <KeyRound className="h-5 w-5" /> Permissions & redaction
+                </CardTitle>
+                <CardDescription className="text-slate-300">
+                  Every line item is reviewed for confidentiality before it leaves the internal system.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-slate-200">
+                <p>Client aliases default to anonymized names until explicit publishing approval is captured.</p>
+                <p>Sensitive numbers can be redacted while still proving that the engagement existed and was paid for.</p>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-slate-800/70 border border-slate-700">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-white">
+                  <Lock className="h-5 w-5" /> Evidence linking
+                </CardTitle>
+                <CardDescription className="text-slate-300">
+                  Each transaction will eventually link to transcripts, briefs, and deliverables that prove the work.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-slate-200">
+                <p>Artifacts are organized in shared drives with expiring, permissioned URLs before being surfaced on this page.</p>
+                <p>The ledger acts as the launch pad for AI-assisted case study assembly.</p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-24">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card className="border border-slate-200">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-slate-900">
+                  <Workflow className="h-5 w-5 text-secondary" /> Implementation checklist
+                </CardTitle>
+                <CardDescription>
+                  Concrete steps to bring the fully automated ledger online.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-slate-600">
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-secondary" />
+                  <span>Secure read-only API keys for Mercury, Stripe, and Square. Store them in environment variables within the deployment platform.</span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-secondary" />
+                  <span>Stand up ingestion script (scheduled function or serverless cron) that hydrates the internal warehouse.</span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-secondary" />
+                  <span>Tag and deduplicate deposits that originate from payment processors before they hit Mercury.</span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-secondary" />
+                  <span>Attach supporting transcripts, briefs, and approvals as structured metadata in Notion or a lightweight CMS.</span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-secondary" />
+                  <span>Expose a read-only API endpoint or static JSON feed that this page can poll for updates.</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border border-slate-200">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-slate-900">
+                  <GitBranch className="h-5 w-5 text-secondary" /> Delivery roadmap
+                </CardTitle>
+                <CardDescription>
+                  Milestones that track progress toward a fully public ledger experience.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {ledgerRoadmap.map((item) => (
+                  <div key={item.id} className="rounded-lg border border-slate-200 bg-white p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-base font-semibold text-slate-900">{item.milestone}</h3>
+                      <Badge
+                        className={`capitalize ${
+                          item.status === "complete"
+                            ? "bg-emerald-100 text-emerald-700 border-emerald-200"
+                            : item.status === "in-progress"
+                            ? "bg-secondary/10 text-secondary border-secondary/20"
+                            : "bg-slate-100 text-slate-600 border-slate-200"
+                        }`}
+                      >
+                        {item.status.replace("-", " ")}
+                      </Badge>
+                    </div>
+                    {item.targetDate && (
+                      <p className="mt-1 text-xs text-slate-400">Target: {item.targetDate}</p>
+                    )}
+                    <p className="mt-3 text-sm text-slate-600">{item.description}</p>
+                    {item.dependencies && (
+                      <p className="mt-2 text-xs text-slate-400">Depends on: {item.dependencies.join(", ")}</p>
+                    )}
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="pb-24">
+        <div className="mx-auto max-w-3xl text-center px-6 lg:px-0">
+          <h2 className="text-3xl font-semibold text-slate-900">Want your success story recorded here?</h2>
+          <p className="mt-4 text-lg text-slate-600">
+            Book a strategy conversation, become a ledger entry, and unlock the evidence trail that showcases what we built together.
+          </p>
+          <a
+            href="https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call"
+            className="mt-6 inline-flex items-center justify-center gap-2 rounded-full bg-secondary px-6 py-3 text-white shadow-lg hover:bg-secondary/90 transition"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Schedule a strategy session
+            <ArrowRight className="h-4 w-4" />
+          </a>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default LedgerPage;


### PR DESCRIPTION
## Summary
- replace the nonexistent lucide-react Api icon with the available Workflow glyph on the ledger page to restore production builds and previews

## Testing
- npm run lint
- npm run build
- npm run test:seo


------
https://chatgpt.com/codex/tasks/task_b_68d80f7361c08333b25f794d63c527f0