### PR TITLE
Update pricing to Bitcoin with live USD conversion

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,73 +3,73 @@
   
   <url>
     <loc>https://gsdat.work/</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://gsdat.work/cases</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-tooling-report</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/10x-executive</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-action-workshop</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-legal-workshop</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/ai-automation-integration</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/associate-program</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/methodology</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/triple-a-transformation</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/blog</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://gsdat.work/qualitative-data-insights-workshop</loc>
-    <lastmod>2025-08-25</lastmod>
+    <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/components/EngagementLevels.test.tsx
+++ b/src/components/EngagementLevels.test.tsx
@@ -7,6 +7,22 @@ import { EngagementLevels } from './EngagementLevels'
 // Mock window.open
 global.window.open = vi.fn()
 
+// Mock the useBitcoinPrice hook
+vi.mock('@/hooks/use-bitcoin-price', () => ({
+  useBitcoinPrice: () => ({
+    data: 95000, // Mock BTC price
+    isLoading: false,
+    error: null
+  }),
+  btcToUsd: (btcAmount: number, btcPrice: number) => btcAmount * btcPrice,
+  formatUsd: (amount: number) => new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}))
+
 // Wrapper component for React Router
 const renderWithRouter = (component: React.ReactElement) => {
   return render(<BrowserRouter>{component}</BrowserRouter>)
@@ -26,11 +42,12 @@ describe('EngagementLevels', () => {
 
   it('renders both engagement paths', () => {
     renderWithRouter(<EngagementLevels />)
-    
+
     // Quick Win path
-    expect(screen.getByText('AI Action Workshop - Quick Win')).toBeInTheDocument()
-    expect(screen.getByText('$4,999')).toBeInTheDocument()
-    
+    expect(screen.getByText('Quick Win in a Box')).toBeInTheDocument()
+    // Should show USD price (mocked at $4,750)
+    expect(screen.getByText('$4,750')).toBeInTheDocument()
+
     // Transformation path
     expect(screen.getByText('AI Transformation Programs')).toBeInTheDocument()
     expect(screen.getByText('Custom Engagement Pricing')).toBeInTheDocument()
@@ -38,11 +55,12 @@ describe('EngagementLevels', () => {
 
   it('renders all quick win features', () => {
     renderWithRouter(<EngagementLevels />)
-    
-    expect(screen.getByText('1-2 hour hands-on workshop')).toBeInTheDocument()
-    expect(screen.getByText('Founder-led ($4,999) or Associate-led (competitive rates)')).toBeInTheDocument()
+
+    expect(screen.getByText('1-2 hour hands-on session')).toBeInTheDocument()
+    expect(screen.getByText('Founder-led or Associate-led (competitive rates)')).toBeInTheDocument()
     expect(screen.getByText('Transform a 2-day task into 2 hours')).toBeInTheDocument()
     expect(screen.getByText('Create reusable processes & SOPs')).toBeInTheDocument()
+    expect(screen.getByText('Bundle discounts: 20% (5-pack) or 30% (10-pack)')).toBeInTheDocument()
   })
 
   it('renders all transformation program features', () => {
@@ -61,10 +79,10 @@ describe('EngagementLevels', () => {
     expect(screen.getByText('Begin your AI journey today with the approach that fits your needs.')).toBeInTheDocument()
   })
 
-  it('has correct link to AI Action Workshop', () => {
+  it('has correct link to Quick Win page', () => {
     renderWithRouter(<EngagementLevels />)
-    
-    const workshopLink = screen.getByRole('link', { name: /Explore Workshop Options/i })
+
+    const workshopLink = screen.getByRole('link', { name: /Explore Quick Win Options/i })
     expect(workshopLink).toHaveAttribute('href', '/ai-action-workshop')
   })
 
@@ -99,11 +117,11 @@ describe('EngagementLevels', () => {
 
   it('renders with proper visual hierarchy', () => {
     renderWithRouter(<EngagementLevels />)
-    
+
     // Check that both cards exist with proper structure
-    const quickWinCard = screen.getByText('AI Action Workshop - Quick Win').closest('div[class*="rounded-xl"]')
+    const quickWinCard = screen.getByText('Quick Win in a Box').closest('div[class*="rounded-xl"]')
     const transformCard = screen.getByText('AI Transformation Programs').closest('div[class*="rounded-xl"]')
-    
+
     expect(quickWinCard).toHaveClass('border-blue-200')
     expect(transformCard).toHaveClass('border-secondary')
   })

--- a/src/components/EngagementLevels.tsx
+++ b/src/components/EngagementLevels.tsx
@@ -2,8 +2,15 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight, Zap, Target } from "lucide-react";
 import { Link } from "react-router-dom";
 import { animations, spacing } from "@/lib/design-tokens";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 export const EngagementLevels = () => {
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+  const quickWinBtc = 0.05;
+
+  // Calculate USD equivalent
+  const quickWinUsd = btcPrice ? formatUsd(btcToUsd(quickWinBtc, btcPrice)) : null;
+
   return (
     <section className={`${spacing.section.lg} bg-gradient-to-b from-gray-50 to-white`}>
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -25,26 +32,33 @@ export const EngagementLevels = () => {
             </div>
             
             <h3 className="text-2xl font-bold text-gray-900 mb-3">
-              AI Action Workshop - Quick Win
+              Quick Win in a Box
             </h3>
-            
-            <p className="text-lg font-semibold text-blue-600 mb-4">
-              $4,999
-            </p>
-            
+
+            <div className="mb-4">
+              {quickWinUsd && !btcLoading ? (
+                <>
+                  <p className="text-lg font-semibold text-blue-600">{quickWinUsd}</p>
+                  <p className="text-sm text-gray-600">(0.05 BTC)</p>
+                </>
+              ) : (
+                <p className="text-lg font-semibold text-blue-600">0.05 BTC</p>
+              )}
+            </div>
+
             <p className="text-gray-700 mb-6">
-              Perfect for teams ready to experience immediate AI impact. Break your 
+              Perfect for teams ready to experience immediate AI impact. Break your
               four-minute mile in a single hands-on session.
             </p>
-            
+
             <ul className="space-y-3 mb-8">
               <li className="flex items-start">
                 <span className="text-blue-600 mr-2">✓</span>
-                <span className="text-gray-700">1-2 hour hands-on workshop</span>
+                <span className="text-gray-700">1-2 hour hands-on session</span>
               </li>
               <li className="flex items-start">
                 <span className="text-blue-600 mr-2">✓</span>
-                <span className="text-gray-700">Founder-led ($4,999) or Associate-led (competitive rates)</span>
+                <span className="text-gray-700">Founder-led or Associate-led (competitive rates)</span>
               </li>
               <li className="flex items-start">
                 <span className="text-blue-600 mr-2">✓</span>
@@ -54,12 +68,16 @@ export const EngagementLevels = () => {
                 <span className="text-blue-600 mr-2">✓</span>
                 <span className="text-gray-700">Create reusable processes & SOPs</span>
               </li>
+              <li className="flex items-start">
+                <span className="text-blue-600 mr-2">✓</span>
+                <span className="text-gray-700">Bundle discounts: 20% (5-pack) or 30% (10-pack)</span>
+              </li>
             </ul>
             
             <div className="space-y-3">
               <Link to="/ai-action-workshop" className="block">
                 <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white">
-                  Explore Workshop Options
+                  Explore Quick Win Options
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
               </Link>

--- a/src/components/internal-linking/ServiceComparison.tsx
+++ b/src/components/internal-linking/ServiceComparison.tsx
@@ -4,6 +4,7 @@ import { Check, ArrowRight, Clock, Users, Target } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 interface ServiceComparisonProps {
   title?: string;
@@ -18,12 +19,21 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
   showAllServices = true,
   highlightService
 }) => {
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+
+  // Calculate USD equivalent
+  const getUsdEquivalent = (btcAmount?: number) => {
+    if (!btcAmount || !btcPrice) return null;
+    return formatUsd(btcToUsd(btcAmount, btcPrice));
+  };
+
   const services = [
     {
       id: "enterprise-ai-cooking-show",
       name: "Enterprise AI Cooking Show",
       subtitle: "Live Transformation Workshop",
-      price: "$4,999",
+      price: "0.05 BTC",
+      btcPrice: 0.05,
       duration: "Live Session",
       ideal: "Enterprise teams & mastermind groups",
       icon: <Clock className="h-6 w-6" />,
@@ -46,7 +56,8 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
       id: "ai-oracle-session",
       name: "AI Oracle Session",
       subtitle: "Executive Intelligence System",
-      price: "$2,499",
+      price: "0.05 BTC",
+      btcPrice: 0.05,
       duration: "Setup & Integration",
       ideal: "C-suite & senior leadership",
       icon: <Clock className="h-6 w-6" />,
@@ -67,9 +78,10 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
     },
     {
       id: "ai-action-workshop",
-      name: "AI Action Workshop",
+      name: "Quick Win in a Box",
       subtitle: "Quick Start Implementation",
-      price: "$4,999",
+      price: "0.05 BTC",
+      btcPrice: 0.05,
       duration: "Quick Win Implementation",
       ideal: "Individual contributors, small teams",
       icon: <Target className="h-6 w-6" />,
@@ -80,35 +92,12 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
         "Working AI solution by end of session",
         "Transferable frameworks and SOPs",
         "Follow-up support and templates",
-        "Perfect for testing our approach"
+        "Performance-based pricing available"
       ],
       outcomes: [
         "100-2000% efficiency gains",
         "10X transformation in hours not days",
         "Ready-to-use processes"
-      ]
-    },
-    {
-      id: "10x-executive",
-      name: "10x Executive Program",
-      subtitle: "Executive & Team Transformation",
-      price: "$19,999",
-      duration: "10 weeks",
-      ideal: "Executives and their teams",
-      icon: <Users className="h-6 w-6" />,
-      color: "bg-purple-500",
-      link: "/10x-executive",
-      features: [
-        "5 bi-weekly sessions (2 hours each)",
-        "Team members welcome to join",
-        "Organization-wide AI implementation",
-        "Scalable automation frameworks",
-        "Session recordings for knowledge sharing"
-      ],
-      outcomes: [
-        "10x productivity across teams",
-        "Organization-wide AI adoption",
-        "Scalable AI processes"
       ]
     },
     {
@@ -138,9 +127,10 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
       id: "triple-a-transformation",
       name: "Triple-A Transformation",
       subtitle: "Organizational Change",
-      price: "Custom",
+      price: "Starts at 1 BTC",
+      btcPrice: 1.0,
       duration: "14 weeks",
-      ideal: "Organizations, large teams",
+      ideal: "100+ person organizations",
       icon: <Target className="h-6 w-6" />,
       color: "bg-orange-500",
       link: "/triple-a-transformation",
@@ -149,7 +139,7 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
         "Team-wide transformation program",
         "Measurable ROI and KPI tracking",
         "Change management support",
-        "Custom implementation roadmap"
+        "Performance-based pricing options"
       ],
       outcomes: [
         "Organization-wide AI adoption",
@@ -207,12 +197,26 @@ export const ServiceComparison: React.FC<ServiceComparisonProps> = ({
                   {service.subtitle}
                 </p>
                 
-                <div className="flex items-baseline gap-1">
-                  <span className="text-2xl font-bold text-secondary">
-                    {service.price}
-                  </span>
-                  {service.price !== "Custom" && (
-                    <span className="text-sm text-gray-500">one-time</span>
+                <div className="flex flex-col gap-1">
+                  {service.btcPrice && !btcLoading && getUsdEquivalent(service.btcPrice) ? (
+                    <>
+                      <div className="flex items-baseline gap-1">
+                        <span className="text-2xl font-bold text-secondary">
+                          {getUsdEquivalent(service.btcPrice)}
+                        </span>
+                        <span className="text-sm text-gray-500">one-time</span>
+                      </div>
+                      <span className="text-xs text-gray-500">({service.price})</span>
+                    </>
+                  ) : (
+                    <div className="flex items-baseline gap-1">
+                      <span className="text-2xl font-bold text-secondary">
+                        {service.price}
+                      </span>
+                      {service.price !== "Custom" && !service.price.includes("Starts") && (
+                        <span className="text-sm text-gray-500">one-time</span>
+                      )}
+                    </div>
                   )}
                 </div>
                 

--- a/src/components/navigation/DesktopNavigation.tsx
+++ b/src/components/navigation/DesktopNavigation.tsx
@@ -45,7 +45,7 @@ export const DesktopNavigation = () => {
                           <span className="text-[10px] text-gray-400 uppercase tracking-wider block mb-1">Step 0</span>
                           <span className="text-sm font-medium leading-none">Enterprise AI Cooking Show</span>
                         </div>
-                        <span className="text-xs font-semibold text-secondary bg-secondary/10 px-2 py-1 rounded ml-2">$4,999</span>
+                        <span className="text-xs font-semibold text-secondary bg-secondary/10 px-2 py-1 rounded ml-2">0.05 BTC</span>
                       </div>
                       <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
                         High-energy, live AI transformation workshop
@@ -64,7 +64,7 @@ export const DesktopNavigation = () => {
                           <span className="text-[10px] text-gray-400 uppercase tracking-wider block mb-1">Step 1</span>
                           <span className="text-sm font-medium leading-none">AI Oracle Session</span>
                         </div>
-                        <span className="text-xs font-semibold text-secondary bg-secondary/10 px-2 py-1 rounded ml-2">$2,499</span>
+                        <span className="text-xs font-semibold text-secondary bg-secondary/10 px-2 py-1 rounded ml-2">0.05 BTC</span>
                       </div>
                       <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
                         AI-powered executive intelligence system
@@ -81,9 +81,9 @@ export const DesktopNavigation = () => {
                       <div className="flex items-start justify-between mb-1">
                         <div>
                           <span className="text-[10px] text-gray-400 uppercase tracking-wider block mb-1">Step 2</span>
-                          <span className="text-sm font-medium leading-none">AI Action Workshop</span>
+                          <span className="text-sm font-medium leading-none">Quick Win in a Box</span>
                         </div>
-                        <span className="text-xs font-semibold text-secondary bg-secondary/10 px-2 py-1 rounded ml-2">$4,999</span>
+                        <span className="text-xs font-semibold text-secondary bg-secondary/10 px-2 py-1 rounded ml-2">0.05 BTC</span>
                       </div>
                       <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
                         Quick win in a box - 10X transformation guaranteed

--- a/src/components/services/ServiceCard.pricing.test.tsx
+++ b/src/components/services/ServiceCard.pricing.test.tsx
@@ -7,6 +7,22 @@ import { ServiceType } from './types'
 // Mock window.open
 global.window.open = vi.fn()
 
+// Mock the useBitcoinPrice hook
+vi.mock('@/hooks/use-bitcoin-price', () => ({
+  useBitcoinPrice: () => ({
+    data: 95000, // Mock BTC price
+    isLoading: false,
+    error: null
+  }),
+  btcToUsd: (btcAmount: number, btcPrice: number) => btcAmount * btcPrice,
+  formatUsd: (amount: number) => new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}))
+
 // Wrapper component for React Router
 const renderWithRouter = (component: React.ReactElement) => {
   return render(<BrowserRouter>{component}</BrowserRouter>)

--- a/src/components/services/ServiceCard.tsx
+++ b/src/components/services/ServiceCard.tsx
@@ -13,17 +13,26 @@ import {
 import { ServiceType } from "./types";
 import { ServiceFeaturesList } from "./ServiceFeaturesList";
 import { animations, shadows, typography, borderRadius, gradients } from "@/lib/design-tokens";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 interface ServiceCardProps {
   service: ServiceType;
 }
 
 export const ServiceCard = ({ service }: ServiceCardProps) => {
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+
+  // Calculate USD equivalent if BTC price is available
+  const getUsdEquivalent = (btcAmount?: number) => {
+    if (!btcAmount || !btcPrice) return null;
+    return formatUsd(btcToUsd(btcAmount, btcPrice));
+  };
+
   return (
     <Card className={`group flex flex-col justify-between ${shadows.floating} hover:shadow-xl hover:-translate-y-2 hover:scale-[1.02] transition-all duration-300 ${borderRadius.xl} relative overflow-hidden border-0 ring-1 ring-gray-200/50 hover:ring-secondary/30`}>
       {/* Subtle gradient overlay on hover */}
       <div className="absolute inset-0 bg-gradient-to-br from-secondary/5 to-primary/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
-      
+
       <CardHeader className="relative z-10">
         <CardTitle className="text-xl font-bold">{service.title}</CardTitle>
         <CardDescription className="mt-2">{service.description}</CardDescription>
@@ -37,11 +46,19 @@ export const ServiceCard = ({ service }: ServiceCardProps) => {
         )}
         <ServiceFeaturesList features={service.features} />
         <div className="mt-6">
-          <p className="text-xl font-bold text-primary">{service.price}</p>
+          {/* Show USD as primary, BTC as secondary */}
+          {service.btcPrice && !btcLoading && getUsdEquivalent(service.btcPrice) ? (
+            <>
+              <p className="text-xl font-bold text-primary">{getUsdEquivalent(service.btcPrice)}</p>
+              <p className="text-sm text-gray-600 mt-1">({service.price})</p>
+            </>
+          ) : (
+            <p className="text-xl font-bold text-primary">{service.price}</p>
+          )}
           {service.subtext && (
             <p className="text-sm text-gray-500 mt-1">{service.subtext}</p>
           )}
-          
+
           {/* Display pricing tiers if available */}
           {service.pricingTiers && service.pricingTiers.length > 0 && (
             <div className="mt-4 space-y-3">
@@ -56,6 +73,9 @@ export const ServiceCard = ({ service }: ServiceCardProps) => {
                     </div>
                     <div className="text-right">
                       <p className="font-bold text-secondary">{tier.price}</p>
+                      {tier.btcPrice && !btcLoading && getUsdEquivalent(tier.btcPrice) && (
+                        <p className="text-xs text-gray-600 mt-0.5">≈ {getUsdEquivalent(tier.btcPrice)}</p>
+                      )}
                       {tier.availability && (
                         <p className="text-xs text-gray-500 mt-0.5">{tier.availability}</p>
                       )}

--- a/src/components/services/data.test.ts
+++ b/src/components/services/data.test.ts
@@ -3,8 +3,8 @@ import { services, valueMetrics } from './data'
 import { ServiceType } from './types'
 
 describe('services data', () => {
-  it('contains exactly 6 services', () => {
-    expect(services).toHaveLength(6)
+  it('contains exactly 5 services', () => {
+    expect(services).toHaveLength(5)
   })
 
   it('all services have required fields', () => {
@@ -51,16 +51,16 @@ describe('services data', () => {
 
   it('service prices follow expected patterns', () => {
     services.forEach((service) => {
-      // Allow both dollar amounts and "Custom Pricing"
-      expect(service.price).toMatch(/(\$[\d,]+|Custom Pricing)/)
+      // Allow dollar amounts, BTC pricing, and "Custom Pricing"
+      expect(service.price).toMatch(/(\$[\d,]+|Custom Pricing|[\d.]+\s*BTC|Starts at)/)
     })
   })
 
   it('all services have at least 5 features', () => {
     services.forEach((service) => {
       expect(service.features.length).toBeGreaterThanOrEqual(5)
-      // 10x Executive has 6 features due to team participation feature
-      expect(service.features.length).toBeLessThanOrEqual(6)
+      // Quick Win in a Box and Triple A have 6-7 features
+      expect(service.features.length).toBeLessThanOrEqual(7)
       service.features.forEach((feature) => {
         expect(typeof feature).toBe('string')
         expect(feature.length).toBeGreaterThan(0)
@@ -70,37 +70,38 @@ describe('services data', () => {
 
   it('contains expected workshop services', () => {
     const workshopTitles = services
-      .filter(s => s.title.includes('Workshop') || s.title.includes('Session') || s.title.includes('Show'))
+      .filter(s => s.title.includes('Workshop') || s.title.includes('Session') || s.title.includes('Show') || s.title.includes('Box'))
       .map(s => s.title)
 
     expect(workshopTitles).toContain('AI Oracle Session')
-    expect(workshopTitles).toContain('AI Action Workshop')
+    expect(workshopTitles).toContain('Quick Win in a Box')
     expect(workshopTitles).toContain('Enterprise AI Cooking Show')
     expect(workshopTitles).toHaveLength(3)
   })
 
   it('contains expected program services', () => {
     const programTitles = services
-      .filter(s => s.title.includes('Program') || s.title.includes('Executive') || s.title.includes('Integration'))
+      .filter(s => s.title.includes('Program') || s.title.includes('Integration'))
       .map(s => s.title)
-    
-    expect(programTitles).toContain('10x Effective Executive')
+
     expect(programTitles).toContain('AI Automation & Custom Integration')
     expect(programTitles).toContain('Triple-A Transformation Program')
-    expect(programTitles).toHaveLength(3)
+    expect(programTitles).toHaveLength(2)
   })
 
   it('workshops have appropriate pricing', () => {
-    const workshops = services.filter(s => s.title.includes('Workshop') || s.title.includes('Session') || s.title.includes('Show'))
+    const workshops = services.filter(s => s.title.includes('Workshop') || s.title.includes('Session') || s.title.includes('Show') || s.title.includes('Box'))
     workshops.forEach((workshop) => {
-      if (workshop.title === 'AI Action Workshop') {
-        expect(workshop.price).toBe('$4,999 per session')
-        expect(workshop.subtext).toBe('Associate-led workshops also available - pricing varies')
+      if (workshop.title === 'Quick Win in a Box') {
+        expect(workshop.price).toBe('0.05 BTC per session')
+        expect(workshop.btcPrice).toBe(0.05)
       } else if (workshop.title === 'AI Oracle Session') {
-        expect(workshop.price).toBe('$2,499 per session')
+        expect(workshop.price).toBe('0.05 BTC per session')
+        expect(workshop.btcPrice).toBe(0.05)
         expect(workshop.subtext).toBe('Executive Intelligence System')
       } else if (workshop.title === 'Enterprise AI Cooking Show') {
-        expect(workshop.price).toBe('$4,999')
+        expect(workshop.price).toBe('0.05 BTC')
+        expect(workshop.btcPrice).toBe(0.05)
         expect(workshop.subtext).toBe('Premium workshop experience')
       }
     })
@@ -117,8 +118,7 @@ describe('services data', () => {
     const expectedRoutes = {
       'Enterprise AI Cooking Show': '/enterprise-ai-cooking-show',
       'AI Oracle Session': '/ai-oracle-session',
-      'AI Action Workshop': '/ai-action-workshop',
-      '10x Effective Executive': '/10x-executive',
+      'Quick Win in a Box': '/ai-action-workshop',
       'AI Automation & Custom Integration': '/ai-automation-integration',
       'Triple-A Transformation Program': '/triple-a-transformation'
     }
@@ -131,9 +131,7 @@ describe('services data', () => {
   it('calendly links are valid and appropriate', () => {
     services.forEach((service) => {
       expect(service.calendlyLink).toBeDefined()
-      if (service.title === '10x Effective Executive') {
-        expect(service.calendlyLink).toBe('https://calendly.com/gsdatwork/10x-executive-consult')
-      } else if (service.title === 'AI Action Workshop') {
+      if (service.title === 'Quick Win in a Box') {
         expect(service.calendlyLink).toBe('https://calendly.com/gsdatwork/free-consult')
       } else {
         expect(service.calendlyLink).toBe('https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call')

--- a/src/components/services/data.ts
+++ b/src/components/services/data.ts
@@ -5,7 +5,8 @@ export const services: ServiceType[] = [
   {
     title: "Enterprise AI Cooking Show",
     description: "High-energy, live AI transformation demonstration that gets your team excited about what's possible with AI",
-    price: "$4,999",
+    price: "0.05 BTC",
+    btcPrice: 0.05,
     subtext: "Premium workshop experience",
     extraText: "Perfect for enterprises and mastermind groups. Watch real transformations happen live, participate in hands-on demonstrations, and leave with the excitement and knowledge to kickstart your AI journey.",
     features: [
@@ -23,7 +24,8 @@ export const services: ServiceType[] = [
   {
     title: "AI Oracle Session",
     description: "Transform executive decision-making with AI-powered organizational insights that integrate into your leadership cadence",
-    price: "$2,499 per session",
+    price: "0.05 BTC per session",
+    btcPrice: 0.05,
     subtext: "Executive Intelligence System",
     extraText: "See what others miss. AI Oracle provides C-suite teams with strategic foresight, identifies hidden risks and opportunities, and becomes an ongoing participant in executive decision-making.",
     features: [
@@ -39,21 +41,23 @@ export const services: ServiceType[] = [
     learnMoreLink: "/ai-oracle-session",
   },
   {
-    title: "AI Action Workshop",
-    description: "Quick win in a box: Transform what takes days or weeks into hours. Break your four-minute mile with AI and gain the know-how to replicate success across your organization",
-    price: "$4,999 per session",
-    subtext: "Associate-led workshops also available - pricing varies",
-    extraText: "100-2000% efficiency gain for targeted tasks. Participants develop transferable SOPs, reduce cycle times, and maintain significantly higher energy levels throughout the workday.",
+    title: "Quick Win in a Box",
+    description: "Get to your outcome by a negotiated time. No more than 3 hours of sponsor team time required. Everything from accelerated contract review to massively faster hiring, financial analysis, GTM prospecting, software development, and analysis of massive unstructured datasets.",
+    price: "0.05 BTC per session",
+    btcPrice: 0.05,
+    subtext: "Performance-based: 50% upfront, 50% upon verified success. Bundle discounts available.",
+    extraText: "100-2000% efficiency gain for targeted tasks. We negotiate the outcome beforehand, figure out the scope, and get there in a live working session (90-120 min typically). You'll develop transferable SOPs, reduce cycle times 10x faster, and maintain significantly higher energy levels throughout the workday.",
     pricingTiers: [
       {
-        label: 'Founder-Led Workshop',
-        price: '$4,999',
+        label: 'Founder-Led Session',
+        price: '0.05 BTC',
+        btcPrice: 0.05,
         description: 'Led by Christian Ulstrup',
         availability: 'Limited availability',
         calendlyLink: 'https://calendly.com/gsdatwork/ai-workshop'
       },
       {
-        label: 'Associate-Led Workshop',
+        label: 'Associate-Led Session',
         price: 'pricing varies',
         description: 'Led by GSD Certified Associates',
         availability: 'More flexible scheduling',
@@ -66,30 +70,12 @@ export const services: ServiceType[] = [
       "Create documented processes that spread success virally",
       "Break your four-minute mile - prove what's possible with AI",
       "Includes pre-session discovery and post-session support",
+      "Performance-based: 50% upfront, 50% upon verified success"
     ],
     cta: "Learn More",
     secondaryCta: "Schedule a Consultation",
     calendlyLink: "https://calendly.com/gsdatwork/free-consult",
     learnMoreLink: "/ai-action-workshop",
-  },
-  {
-    title: "10x Effective Executive",
-    description: "A 10-week AI-powered transformation program for executives and their teams to accelerate productivity, reclaim time, and master AI tools organization-wide",
-    price: "$19,999",
-    subtext: "One-time engagement fee",
-    extraText: "Transform your organization's productivity through executive leadership. Cut email handling time by 50-80%, reclaim 10+ hours weekly for strategic work, and create scalable AI systems that benefit your entire team.",
-    features: [
-      "5 bi-weekly coaching sessions (2 hours each)",
-      "Team members welcome to join relevant sessions",
-      "Personalized AI tool stack for your organization",
-      "Cut email handling time by 50-80% across your team",
-      "Build scalable AI processes that spread success",
-      "Measurable outcomes tied to organizational results",
-    ],
-    cta: "Learn More",
-    secondaryCta: "Schedule a Consultation",
-    calendlyLink: "https://calendly.com/gsdatwork/10x-executive-consult",
-    learnMoreLink: "/10x-executive",
   },
   {
     title: "AI Automation & Custom Integration",
@@ -113,15 +99,18 @@ export const services: ServiceType[] = [
   {
     title: "Triple-A Transformation Program",
     description: "14-week program to revolutionize your operations with AI (Triple-A = Accelerated AI Adoption)",
-    price: "Starts at $150,000 for 100+ person organizations",
-    subtext: "Includes performance-based incentives and scales with org size",
-    extraText: "Organization-wide efficiency gains leading to significant cost reduction, accelerated growth in new markets, greater velocity in delivering offerings, and elevated employee energy levels across teams.",
+    price: "Starts at 1 BTC for 100+ person organizations",
+    btcPrice: 1.0,
+    subtext: "Includes performance-based incentives - Pay full upfront OR share 10-20¢ per EBITDA dollar created",
+    extraText: "Organization-wide efficiency gains leading to significant cost reduction, accelerated growth in new markets, greater velocity in delivering offerings, and elevated employee energy levels across teams. Performance incentives based on CFO-signed 1-year EBITDA with time/certainty discounts. For forward-thinking clients, we can structure prediction markets (see arlofs.pro) to incentivize employee participation in transformation.",
     features: [
       "Fractional Chief AI Officer services",
       "Comprehensive AI opportunity assessment",
       "Custom implementation roadmap",
       "Team training and change management",
       "ROI-focused metrics and tracking",
+      "Performance-based: Full BTC upfront OR 10-20¢/$1 EBITDA created",
+      "Optional: Prediction market incentives for employee engagement"
     ],
     cta: "Learn More",
     secondaryCta: "Schedule a Strategy Call",

--- a/src/components/services/types.ts
+++ b/src/components/services/types.ts
@@ -2,16 +2,26 @@
 export interface PricingTier {
   label: string;
   price: string;
+  btcPrice?: number; // Price in BTC
   description?: string;
   calendlyLink?: string;
   availability?: string;
+}
+
+export interface BundlePricing {
+  quantity: number;
+  discount: number; // Percentage discount
+  upfrontPercentage: number; // Percentage required upfront
+  description: string;
 }
 
 export interface ServiceType {
   title: string;
   description: string;
   price: string;
+  btcPrice?: number; // Price in BTC (for dynamic USD conversion)
   pricingTiers?: PricingTier[];
+  bundlePricing?: BundlePricing[]; // For services that offer bundle discounts
   subtext?: string;
   extraText?: string;
   features: string[];

--- a/src/hooks/use-bitcoin-price.ts
+++ b/src/hooks/use-bitcoin-price.ts
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+
+interface BitcoinPriceResponse {
+  bitcoin: {
+    usd: number;
+  };
+}
+
+/**
+ * Fetches the current Bitcoin price in USD from CoinGecko API
+ */
+const fetchBitcoinPrice = async (): Promise<number> => {
+  const response = await fetch(
+    'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd'
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch Bitcoin price');
+  }
+
+  const data: BitcoinPriceResponse = await response.json();
+
+  // Validate response structure
+  if (!data.bitcoin || typeof data.bitcoin.usd !== 'number') {
+    throw new Error('Invalid Bitcoin price response structure');
+  }
+
+  return data.bitcoin.usd;
+};
+
+/**
+ * Hook to get current Bitcoin price in USD
+ * Refetches every 5 minutes to keep price relatively current
+ */
+export const useBitcoinPrice = () => {
+  return useQuery({
+    queryKey: ['bitcoinPrice'],
+    queryFn: fetchBitcoinPrice,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
+    retry: 3,
+  });
+};
+
+/**
+ * Converts BTC amount to USD
+ */
+export const btcToUsd = (btcAmount: number, btcPriceUsd: number): number => {
+  return btcAmount * btcPriceUsd;
+};
+
+/**
+ * Formats USD amount as currency string
+ */
+export const formatUsd = (amount: number): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+};

--- a/src/pages/AIActionWorkshop.tsx
+++ b/src/pages/AIActionWorkshop.tsx
@@ -11,9 +11,15 @@ import { KeywordOptimizedSEO } from "@/components/seo/KeywordOptimizedSEO";
 import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
 import { ServiceRecommendation } from "@/components/internal-linking/ServiceRecommendation";
 import { animations, shadows, typography, gradients, buttonStyles, layouts, borderRadius } from "@/lib/design-tokens";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 const AIActionWorkshop = () => {
-  const workshop = services.find(s => s.title === "AI Action Workshop");
+  const workshop = services.find(s => s.title === "Quick Win in a Box");
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+  const btcAmount = 0.05;
+
+  // Calculate USD equivalent
+  const usdPrice = btcPrice ? formatUsd(btcToUsd(btcAmount, btcPrice)) : null;
   
   if (!workshop) return null;
   
@@ -30,14 +36,14 @@ const AIActionWorkshop = () => {
     "https://gsdat.work/ai-action-workshop",
     "https://gsdat.work/lovable-uploads/34b71833-b38f-4c6a-b8d2-4d9b3dcc99f3.png",
     "GSD at Work",
-    "$4,999"
+    "0.05 BTC"
   );
 
   // Enhanced FAQ structured data with more comprehensive answers
   const faqStructuredData = generateFAQStructuredData([
     {
-      question: "What is the AI Action Workshop?",
-      answer: "The AI Action Workshop is your quick win in a box - a hands-on session where you'll break your four-minute mile with AI. Transform tasks that take days or weeks into victories achieved in hours, while gaining the know-how to replicate this success across your organization."
+      question: "What is the Quick Win in a Box?",
+      answer: "Quick Win in a Box is your outcome-based engagement - a hands-on session where you'll break your four-minute mile with AI. Transform tasks that take days or weeks into victories achieved in hours, while gaining the know-how to replicate this success across your organization. You get to your outcome by a negotiated time with no more than 3 hours of sponsor team time required."
     },
     {
       question: "Who should attend the AI Action Workshop?",
@@ -52,8 +58,8 @@ const AIActionWorkshop = () => {
       answer: "Participants typically achieve 100-2000% efficiency gains for targeted tasks. You'll develop transferable SOPs, reduce cycle times, and maintain higher energy levels throughout your workday by eliminating tedious tasks."
     },
     {
-      question: "How much does the AI Action Workshop cost?",
-      answer: "The AI Action Workshop is $4,999 for a Founder-led workshop with Christian Ulstrup. We also offer Associate-led workshops with our GSD Certified Associates at competitive rates - perfect for organizations needing flexible scheduling or multiple workshops. Both deliver the same transformative results and satisfaction guarantee."
+      question: "How much does the Quick Win in a Box cost?",
+      answer: "Quick Win in a Box is 0.05 BTC for a Founder-led session with Christian Ulstrup. We also offer Associate-led sessions with our GSD Certified Associates at competitive rates. Bundle pricing available: 5-pack with 20% off, or 10-pack with 30% off (50% upfront, 50% upon verified quick win achievement). Both deliver the same transformative results and satisfaction guarantee."
     },
     {
       question: "How does the workshop process work?",
@@ -69,7 +75,7 @@ const AIActionWorkshop = () => {
     <div className="min-h-screen bg-background">
       <KeywordOptimizedSEO 
         title="AI Action Workshop | GSD at Work - Get Stuff Done with AI"
-        content="GSD at Work's AI Action Workshop ($4,999): Break your four-minute mile with AI. Transform tasks that take days into victories achieved in hours. Founder-led workshops with hands-on implementation and immediate results."
+        content="GSD at Work's Quick Win in a Box (0.05 BTC): Break your four-minute mile with AI. Transform tasks that take days into victories achieved in hours. Founder-led sessions with hands-on implementation and immediate results. Bundle discounts available."
         canonicalUrl="https://gsdat.work/ai-action-workshop"
         pageType="service"
         structuredData={[serviceStructuredData, faqStructuredData]}
@@ -94,7 +100,7 @@ const AIActionWorkshop = () => {
                 </Badge>
                 
                 <h1 className={`${typography.fluid.h1} text-primary mb-6 leading-tight`}>
-                  AI Action Workshop
+                  Quick Win in a Box
                   <span className="block text-secondary mt-2">Your Four-Minute Mile Moment</span>
                 </h1>
                 
@@ -130,9 +136,9 @@ const AIActionWorkshop = () => {
                     onClick={() => window.open('https://calendly.com/gsdatwork/ai-workshop', '_blank')}
                   >
                     <Calendar className="h-5 w-5 mr-2" />
-                    Book Your Workshop
+                    Book Your Session
                     <span className="absolute -top-2 -right-2 bg-gradient-to-r from-yellow-400 to-orange-500 text-xs font-bold px-2 py-1 rounded-full text-white shadow-lg">
-                      $4,999
+                      {usdPrice || "0.05 BTC"}
                     </span>
                   </Button>
                   
@@ -336,18 +342,30 @@ const AIActionWorkshop = () => {
                 <h2 className={`${typography.fluid.h2} text-primary mb-8`}>
                   Investment & Availability
                 </h2>
-                
-                {/* Founder-Led Workshop */}
+
+                {/* Founder-Led Session */}
                 <Card className={`relative overflow-hidden border-2 border-secondary/50 ${shadows.floating} ${animations.breathingGlow}`}>
                   <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-yellow-400 to-orange-500 text-white text-center py-2 text-sm font-bold">
                     🔥 Most Popular
                   </div>
                   <CardHeader className="pt-12 pb-6">
-                    <CardTitle className="text-xl font-bold text-gray-900">Founder-Led Workshop</CardTitle>
+                    <CardTitle className="text-xl font-bold text-gray-900">Founder-Led Session</CardTitle>
                     <p className="text-gray-600">Led by Christian Ulstrup</p>
-                    <div className="flex items-baseline gap-2 mt-4">
-                      <span className="text-4xl font-bold text-secondary">$4,999</span>
-                      <span className="text-gray-500">one-time</span>
+                    <div className="flex flex-col gap-1 mt-4">
+                      {usdPrice && !btcLoading ? (
+                        <>
+                          <div className="flex items-baseline gap-2">
+                            <span className="text-4xl font-bold text-secondary">{usdPrice}</span>
+                            <span className="text-gray-500">one-time</span>
+                          </div>
+                          <span className="text-sm text-gray-600">(0.05 BTC)</span>
+                        </>
+                      ) : (
+                        <div className="flex items-baseline gap-2">
+                          <span className="text-4xl font-bold text-secondary">0.05 BTC</span>
+                          <span className="text-gray-500">one-time</span>
+                        </div>
+                      )}
                     </div>
                     <Badge variant="outline" className="w-fit mt-2 text-orange-600 border-orange-200">
                       Limited availability
@@ -363,18 +381,18 @@ const AIActionWorkshop = () => {
                       }}
                     >
                       <Calendar className="h-5 w-5 mr-2" />
-                      Book Workshop Now
+                      Book Session Now
                     </Button>
                   </CardContent>
                 </Card>
-                
-                {/* Associate-Led Workshop */}
+
+                {/* Associate-Led Session */}
                 <Card className={`border-2 border-blue-200 ${shadows.floating} hover:shadow-xl transition-all duration-300`}>
                   <CardHeader>
-                    <CardTitle className="text-xl font-bold text-gray-900">Associate-Led Workshops</CardTitle>
+                    <CardTitle className="text-xl font-bold text-gray-900">Associate-Led Sessions</CardTitle>
                     <p className="text-gray-600 text-sm">
-                      Led by our GSD Certified Associates—hand-picked and trained by Christian to deliver 
-                      the exact same transformative workshop experience.
+                      Led by our GSD Certified Associates—hand-picked and trained by Christian to deliver
+                      the exact same transformative session experience.
                     </p>
                     <div className="mt-4">
                       <div className="text-2xl font-bold text-blue-600 mb-2">Competitive Rates</div>
@@ -430,11 +448,18 @@ const AIActionWorkshop = () => {
                     <div className="flex items-start gap-3">
                       <Target className="h-6 w-6 text-blue-600 mt-1" />
                       <div>
-                        <h4 className="font-bold text-blue-900 mb-2">🎯 Volume Discounts Available</h4>
-                        <p className="text-blue-800 text-sm">
-                          Planning multiple workshops? Bundle pricing available starting at 10 workshops. 
-                          Ask about our organizational transformation packages.
-                        </p>
+                        <h4 className="font-bold text-blue-900 mb-2">🎯 Bundle Pricing Available</h4>
+                        <div className="space-y-2">
+                          <div className="text-blue-800 text-sm">
+                            <strong>5-Pack Bundle:</strong> 20% off (50% upfront, 50% upon verified quick win achievement)
+                          </div>
+                          <div className="text-blue-800 text-sm">
+                            <strong>10-Pack Bundle:</strong> 30% off (50% upfront, 50% upon verified quick win achievement)
+                          </div>
+                          <p className="text-blue-700 text-xs mt-3 italic">
+                            Perfect for organizations needing multiple Quick Wins across different teams or departments.
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </Card>

--- a/src/pages/AIOracleSession.tsx
+++ b/src/pages/AIOracleSession.tsx
@@ -4,17 +4,24 @@ import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { SEOHead } from "@/components/SEOHead";
 import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
-import { 
-  Database, Files, Clock, MessageSquare, 
-  DollarSign, Zap, Target, Search, 
-  UserRound, Lightbulb, BrainCircuit, Rocket, 
-  CheckCircle, FileText, Mail, Phone, Clipboard, 
+import {
+  Database, Files, Clock, MessageSquare,
+  DollarSign, Zap, Target, Search,
+  UserRound, Lightbulb, BrainCircuit, Rocket,
+  CheckCircle, FileText, Mail, Phone, Clipboard,
   Users, ArrowRight
 } from "lucide-react";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 const AIOracleSession = () => {
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+  const btcAmount = 0.05;
+
+  // Calculate USD equivalent
+  const usdPrice = btcPrice ? formatUsd(btcToUsd(btcAmount, btcPrice)) : null;
+
   // Calendly links
-  const workshopCalendlyLink = "https://calendly.com/gsdatwork/ai-workshop"; 
+  const workshopCalendlyLink = "https://calendly.com/gsdatwork/ai-workshop";
   const consultationCalendlyLink = "https://calendly.com/d/cst9-jzy-7kj/accelerated-ai-adoption-strategic-planning-call";
 
   // Current date for dateModified schema property
@@ -27,7 +34,7 @@ const AIOracleSession = () => {
     "https://gsdat.work/ai-oracle-session",
     "https://gsdat.work/lovable-uploads/34b71833-b38f-4c6a-b8d2-4d9b3dcc99f3.png",
     "GSD at Work",
-    "$2,499"
+    "0.05 BTC"
   );
 
   // FAQ structured data
@@ -50,7 +57,7 @@ const AIOracleSession = () => {
     },
     {
       question: "How much does the AI Oracle Session cost?",
-      answer: "$2,499 for the initial setup and training session with satisfaction guaranteed. This includes setting up the system for ongoing use in your executive meetings."
+      answer: "0.05 BTC for the initial setup and training session with satisfaction guaranteed. This includes setting up the system for ongoing use in your executive meetings."
     }
   ]);
 
@@ -96,7 +103,7 @@ const AIOracleSession = () => {
                     <div className="bg-secondary/10 p-2 rounded-full">
                       <DollarSign className="h-5 w-5 text-secondary" />
                     </div>
-                    <span className="font-medium">$2,499 Flat Fee</span>
+                    <span className="font-medium">{usdPrice || "0.05 BTC"} Flat Fee</span>
                   </div>
                   <div className="flex items-center gap-3">
                     <div className="bg-secondary/10 p-2 rounded-full">
@@ -447,7 +454,14 @@ const AIOracleSession = () => {
               </h2>
               
               <div className="mb-8">
-                <span className="text-4xl font-bold text-secondary">$2,499</span>
+                {usdPrice && !btcLoading ? (
+                  <>
+                    <span className="text-4xl font-bold text-secondary">{usdPrice}</span>
+                    <p className="text-sm text-gray-600 mt-1">(0.05 BTC)</p>
+                  </>
+                ) : (
+                  <span className="text-4xl font-bold text-secondary">0.05 BTC</span>
+                )}
                 <p className="text-gray-700 mt-2">Initial AI Oracle Setup & Training</p>
                 <p className="text-sm font-medium text-secondary mt-1">Satisfaction Guaranteed</p>
               </div>

--- a/src/pages/EnterpriseAICookingShow.tsx
+++ b/src/pages/EnterpriseAICookingShow.tsx
@@ -4,15 +4,22 @@ import { Footer } from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { SEOHead } from "@/components/SEOHead";
 import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
-import { 
-  Clock, Users, Zap, Target, TrendingUp, 
+import {
+  Clock, Users, Zap, Target, TrendingUp,
   CheckCircle, ArrowRight, Play, Calendar,
   ChefHat, Rocket, Building2, Award,
   Timer, Sparkles, MessageSquare, FileText,
   Video, Code2, Mic, BarChart3
 } from "lucide-react";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 const EnterpriseAICookingShow = () => {
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+  const btcAmount = 0.05;
+
+  // Calculate USD equivalent
+  const usdPrice = btcPrice ? formatUsd(btcToUsd(btcAmount, btcPrice)) : null;
+
   // Calendly links
   const cookingShowCalendlyLink = "https://calendly.com/gsdatwork/cooking-show";
 
@@ -26,7 +33,7 @@ const EnterpriseAICookingShow = () => {
     "https://gsdat.work/enterprise-ai-cooking-show",
     "https://gsdat.work/lovable-uploads/34b71833-b38f-4c6a-b8d2-4d9b3dcc99f3.png",
     "GSD at Work",
-    "$4,999"
+    "0.05 BTC"
   );
 
   // FAQ structured data
@@ -53,7 +60,7 @@ const EnterpriseAICookingShow = () => {
     },
     {
       question: "How much does the Enterprise AI Cooking Show cost?",
-      answer: "$4,999 for a 2-hour workshop with up to 30 participants. This includes pre-workshop discovery, the live session, all created assets, and 30-day follow-up support. Custom packages available for series or extended sessions."
+      answer: "0.05 BTC for a 2-hour workshop with up to 30 participants. This includes pre-workshop discovery, the live session, all created assets, and 30-day follow-up support. Custom packages available for series or extended sessions."
     }
   ]);
 
@@ -659,7 +666,16 @@ const EnterpriseAICookingShow = () => {
                 <div className="bg-white border-2 border-primary rounded-xl p-8">
                   <div className="flex justify-between items-start mb-4">
                     <h3 className="text-2xl font-semibold">Standard Cooking Show</h3>
-                    <span className="text-3xl font-bold text-primary">$4,999</span>
+                    <div className="text-right">
+                      {usdPrice && !btcLoading ? (
+                        <>
+                          <span className="text-3xl font-bold text-primary">{usdPrice}</span>
+                          <p className="text-sm text-gray-600 mt-1">(0.05 BTC)</p>
+                        </>
+                      ) : (
+                        <span className="text-3xl font-bold text-primary">0.05 BTC</span>
+                      )}
+                    </div>
                   </div>
                   <ul className="space-y-3 mb-6">
                     <li className="flex items-center gap-3">

--- a/src/pages/TripleATransformation.tsx
+++ b/src/pages/TripleATransformation.tsx
@@ -7,9 +7,14 @@ import { ServiceFeaturesList } from "@/components/services/ServiceFeaturesList";
 import { services, valueMetrics } from "@/components/services/data";
 import { SEOHead } from "@/components/SEOHead";
 import { generateServicePageStructuredData, generateFAQStructuredData } from "@/lib/seo-utils";
+import { useBitcoinPrice, btcToUsd, formatUsd } from "@/hooks/use-bitcoin-price";
 
 const TripleATransformation = () => {
   const program = services.find(s => s.title === "Triple-A Transformation Program");
+  const { data: btcPrice, isLoading: btcLoading } = useBitcoinPrice();
+
+  // Calculate USD equivalent for 1 BTC
+  const usdPrice = btcPrice ? formatUsd(btcToUsd(1.0, btcPrice)) : null;
   
   if (!program) return null;
 
@@ -85,7 +90,14 @@ const TripleATransformation = () => {
               
               <div className="bg-gray-50 p-6 rounded-lg">
                 <h2 className="text-2xl font-semibold text-primary mb-4">Investment</h2>
-                <p className="text-3xl font-bold text-secondary mb-2">{program.price}</p>
+                {usdPrice && !btcLoading ? (
+                  <>
+                    <p className="text-3xl font-bold text-secondary mb-1">Starts at {usdPrice}</p>
+                    <p className="text-sm text-gray-600 mb-2">(1 BTC for 100+ person organizations)</p>
+                  </>
+                ) : (
+                  <p className="text-3xl font-bold text-secondary mb-2">{program.price}</p>
+                )}
                 <p className="text-gray-600 mb-6">{program.subtext}</p>
                 
                 <div className="space-y-4">


### PR DESCRIPTION
## Summary

- Migrated all service pricing from USD to Bitcoin (BTC)
- Integrated live Bitcoin price fetching via CoinGecko API
- Display USD prices dynamically calculated from BTC with BTC shown in parentheses
- Renamed "AI Action Workshop" to "Quick Win in a Box" for clarity
- Updated "10x Executive Program" to be removed from main service offerings

## Key Changes

**New Bitcoin Integration:**
- Created `useBitcoinPrice` hook with CoinGecko API integration
- Real-time BTC to USD conversion throughout the site
- Graceful fallback to BTC-only display if API fails

**Pricing Updates:**
- Quick Win services: 0.05 BTC (displays as ~$4,750 at current rates)
- Triple-A Transformation: Starts at 1 BTC
- All pricing tiers updated with BTC amounts

**Service Renaming:**
- "AI Action Workshop" → "Quick Win in a Box"
- Updated all references across components, tests, and navigation

**Components Updated:**
- `ServiceCard` - Shows USD with BTC in parentheses
- `EngagementLevels` - Dynamic pricing display
- `ServiceComparison` - BTC pricing with USD equivalents
- `DesktopNavigation` - Updated navigation items

## Test Plan

- [x] All tests pass with mocked Bitcoin prices
- [x] Build succeeds without errors
- [x] Pricing displays correctly with live API
- [x] Graceful fallback when API unavailable
- [x] All service links and navigation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)