### PR TITLE
Improve mobile footer social buttons

### DIFF
--- a/src/components/EnhancedFooter.tsx
+++ b/src/components/EnhancedFooter.tsx
@@ -157,14 +157,14 @@ export const EnhancedFooter = () => {
             {/* Social Links */}
             <div>
               <h4 className="font-medium text-primary mb-3">Follow Us</h4>
-              <div className="space-y-2">
+              <div className="space-y-2 w-full">
                 <a
                   href="https://www.linkedin.com/in/christianulstrup/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center px-4 py-2 bg-[#0A66C2] text-white rounded-lg hover:bg-[#0A66C2]/90 transition-colors"
+                  className="inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2 bg-[#0A66C2] text-white rounded-lg shadow-sm hover:bg-[#0A66C2]/90 transition-colors"
                 >
-                  <Linkedin className="h-4 w-4 mr-2" />
+                  <Linkedin className="h-4 w-4" />
                   <span>Connect on LinkedIn</span>
                 </a>
 

--- a/src/components/GSDCoinBadge.tsx
+++ b/src/components/GSDCoinBadge.tsx
@@ -110,7 +110,7 @@ export const GSDCoinBadge = () => {
       href={PUMP_FUN_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className={`inline-flex flex-col gap-1 px-4 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white ${borderRadius.lg} hover:from-purple-700 hover:to-pink-700 ${animations.transition} ${shadows.buttonEffect} group`}
+      className={`inline-flex w-full sm:w-auto flex-col gap-1 px-4 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white text-left ${borderRadius.lg} hover:from-purple-700 hover:to-pink-700 ${animations.transition} ${shadows.buttonEffect} group`}
       title="Watch me code live & join the $GSD community"
       aria-label="View $GSD Coin on Pump.fun"
     >


### PR DESCRIPTION
## Summary
- center and expand the LinkedIn follow button so it spans the full column on small screens
- align the $GSD Coin badge width with the LinkedIn button for a cohesive mobile stack

## Testing
- npm run lint
- npm run test:seo

------
https://chatgpt.com/codex/tasks/task_b_68e1326f242c833382af11b5f232cf41